### PR TITLE
Add TyneBoolColumn #8

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,7 +10,7 @@
 
   <PropertyGroup Label="Version settings">
     <TyneMajorVersion>1</TyneMajorVersion>
-    <TyneMinorVersion>3</TyneMinorVersion>
+    <TyneMinorVersion>4</TyneMinorVersion>
     <TynePatchVersion>0</TynePatchVersion>
     <Version>$(TyneMajorVersion).$(TyneMinorVersion).$(TynePatchVersion)</Version>
     <AssemblyVersion>$(Version)</AssemblyVersion>

--- a/src/Tyne.UI/src/Tables/Columns/TyneBoolColumn.razor
+++ b/src/Tyne.UI/src/Tables/Columns/TyneBoolColumn.razor
@@ -1,0 +1,27 @@
+﻿@namespace Tyne.UI.Tables
+@typeparam TResult
+@typeparam TSearch
+@inherits TyneFilteredColumn<TResult, TSearch>
+
+@Render(
+    @<MudRadioGroup T="bool?" SelectedOption="Value" SelectedOptionChanged="SetValueAsync" Class="d-flex flex-column">
+        <MudRadio T="bool?" Option="true">@True</MudRadio>
+        <MudRadio T="bool?" Option="false">@False</MudRadio>
+        <MudRadio T="bool?" Option="null">@Neither</MudRadio>
+    </MudRadioGroup>
+)
+
+@code {
+	protected override RenderFragment RenderPopover(RenderFragment content) =>
+		@<MudPopover Open="IsFilterVisible"
+					 Fixed="true"
+					 AnchorOrigin="Origin.TopLeft"
+					 TransformOrigin="Origin.BottomLeft">
+			<div class="d-flex align-center px-2 py-2">
+				@RenderCloseButton()
+				<div class="d-flex flex-column">
+					@content
+				</div>
+			</div>
+		</MudPopover>;
+}

--- a/src/Tyne.UI/src/Tables/Columns/TyneBoolColumn.razor.cs
+++ b/src/Tyne.UI/src/Tables/Columns/TyneBoolColumn.razor.cs
@@ -1,0 +1,63 @@
+﻿using Microsoft.AspNetCore.Components;
+using System.Linq.Expressions;
+using System.Reflection;
+using Tyne.Queries;
+using Tyne.Utilities;
+
+namespace Tyne.UI.Tables;
+
+public sealed partial class TyneBoolColumn<TResult, TSearch> : TyneFilteredColumn<TResult, TSearch> where TSearch : ISearchQuery
+{
+	protected override bool IsFilterEnabled => Value is not null;
+	private bool? Value { get; set; }
+
+	private PropertyInfo? ForProperty { get; set; }
+	private Expression<Func<TSearch, bool?>>? _for;
+	[Parameter]
+	public Expression<Func<TSearch, bool?>>? For
+	{
+		get => _for;
+		set
+		{
+			_for = value;
+			if (value is null)
+				ForProperty = null;
+			else
+				ForProperty = ExpressionHelper.GetPropertyInfo(value);
+		}
+	}
+
+	[Parameter, EditorRequired]
+	public RenderFragment True { get; set; } = builder => builder.AddContent(0, "True");
+
+	[Parameter, EditorRequired]
+	public RenderFragment False { get; set; } = builder => builder.AddContent(0, "False");
+
+	[Parameter, EditorRequired]
+	public RenderFragment Neither { get; set; } = builder => builder.AddContent(0, "Neither");
+
+	protected override void OnParametersSet()
+	{
+		if (_for is null)
+			throw new InvalidOperationException();
+	}
+
+	public override void Prepare(TSearch search)
+	{
+		if (!IsFilterEnabled)
+			return;
+
+		ForProperty?.SetValue(search, Value);
+	}
+
+	public async Task SetValueAsync(bool? newValue)
+	{
+		if (Value == newValue) return;
+
+		Value = newValue;
+		await OnFilterUpdatedAsync();
+	}
+
+	protected override async Task ClearAsync() =>
+		await SetValueAsync(null);
+}


### PR DESCRIPTION
Adds a `TyneBoolColumn`. Usage:
```razor
<TyneBoolColumn TSearch="Search.Query" TResult="Search.Result" For="entity => entity.IsOpen" OrderBy="entity => entity.IsOpen">
    <ChildContent>
        @* Column header content *@
        Is open
    </ChildContent>
    <True>
        @* Text describing the true state *@
        Open
    </True>
    <False>
        @* Text describing the false state *@
        Closed
    </False>
    <Neither>
        @* Text describing the neither state *@
        Either
    </Neither>
</TyneBoolColumn>
```

Closes #8