### PR TITLE
Add `TyneMetadataDisplay` component

### DIFF
--- a/src/Tyne.Docs/sourcegen/Tyne.Docs.SourceGen.csproj
+++ b/src/Tyne.Docs/sourcegen/Tyne.Docs.SourceGen.csproj
@@ -5,6 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsRoslynComponent>true</IsRoslynComponent>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tyne.Docs/src/Components/Code.razor
+++ b/src/Tyne.Docs/src/Components/Code.razor
@@ -1,0 +1,18 @@
+<code class="@Class">@(Component ? "<" : "")@ChildContent@(Component ? "/>" : "")</code>
+
+@code
+{
+    [Parameter]
+    public bool Inline { get; set; }
+
+    [Parameter]
+    public bool Component { get; set; }
+
+    [Parameter, EditorRequired]
+    public RenderFragment ChildContent { get; set; } = _ => { };
+
+    private string Class => 
+        Inline 
+        ? "tyne-docs-code-inline"
+        : "tyne-docs-code-block";
+}

--- a/src/Tyne.Docs/src/Components/Code.razor.css
+++ b/src/Tyne.Docs/src/Components/Code.razor.css
@@ -1,0 +1,17 @@
+.tyne-docs-code-inline,
+.tyne-docs-code-block {
+    background: var(--mud-palette-grey-lighter);
+    border-radius: 4px;
+}
+
+.tyne-docs-code-inline {
+    display: inline;
+    padding: 2px 4px;
+    margin: 2px 2px;
+}
+
+.tyne-docs-code-block {
+    display: block;
+    padding: 6px 12px;
+    margin: 4px 0px;
+}

--- a/src/Tyne.Docs/src/Pages/UI/MetadataDisplayPage.razor
+++ b/src/Tyne.Docs/src/Pages/UI/MetadataDisplayPage.razor
@@ -1,0 +1,62 @@
+@page "/tyne.ui/metadata-display"
+@using Tyne.Results
+@attribute [DocsPage(PageCategory.UI, "Metadata Display")]
+
+<TyneTitle Value="Metadata Display" />
+
+<MudText Typo="Typo.h3">
+    Metadata Display
+</MudText>
+
+<DocSection>
+    <Title>Overview</Title>
+    <ChildContent>
+        <MudText Typo="Typo.body1">
+            <Code Inline="true" Component="true">TyneMetadataDisplay</Code>
+            is an easy way to render result metadata.
+        </MudText>
+    </ChildContent>
+</DocSection>
+
+<DocSection>
+    <Title>Usage</Title>
+    <ChildContent>
+        <Code Component="true">TyneMetadataDisplay Metadata="{YourMetadata}" Dismissible="@Dismissible.ToString().ToLowerInvariant()" Disabled="@Disabled.ToString().ToLowerInvariant()"</Code>
+        <div class="d-flex flex-row gap-4">
+            <MudSwitch @bind-Checked="Dismissible" Label="Dismissible" Color="Color.Primary" />
+            <MudSwitch @bind-Checked="Disabled" Label="Disabled" Color="Color.Primary" />
+            <MudButton OnClick="ResetResult" Color="Color.Primary" Variant="Variant.Outlined" Class="ml-auto">
+                Reset Metadata
+            </MudButton>
+        </div>
+        <MudCard Class="bg-surface">
+            <MudCardContent>
+                <TyneMetadataDisplay Metadata="DemoResult.Metadata" Dismissible="Dismissible" Disabled="Disabled" />
+            </MudCardContent>
+        </MudCard>
+    </ChildContent>
+</DocSection>
+
+@code 
+{
+    private Result<Unit> DemoResult { get; set; } = default!;
+
+    private bool Disabled { get; set; }
+
+    private bool Dismissible { get; set; } = true;
+
+    protected override void OnInitialized()
+    {
+        ResetResult();
+    }
+
+    private void ResetResult()
+    {
+        DemoResult = Result.Successful(
+            new SuccessMetadata("Thing successful."),
+            new SuccessMetadata("Action taken."),
+            new InfoMetadata("Resource ready."),
+            new ErrorMetadata("Defect detected.")
+        );
+    }
+}

--- a/src/Tyne.Docs/src/_Imports.razor
+++ b/src/Tyne.Docs/src/_Imports.razor
@@ -8,6 +8,7 @@
 @using Microsoft.JSInterop
 @using MudBlazor
 @using Tyne.UI
+@using Tyne.Docs.Components
 @using Tyne.Docs.Services.Pages
 @using Tyne.Docs.Shared
 @using static Tyne.Docs.Shared.DocsUtilities

--- a/src/Tyne.UI/src/MetadataDisplay/TyneMetadataDisplay.razor
+++ b/src/Tyne.UI/src/MetadataDisplay/TyneMetadataDisplay.razor
@@ -1,0 +1,42 @@
+@using Tyne.Results
+@namespace Tyne.UI
+
+@if (Metadata is not null && !Disabled)
+{
+    var successMetadata = Metadata.OfType<ISuccessMetadata>().ToList();
+    var infoMetadata = Metadata.OfType<IInfoMetadata>().ToList();
+    var errorMetadata = Metadata.OfType<IErrorMetadata>().ToList();
+    if (successMetadata.Count > 0 || infoMetadata.Count > 0 || errorMetadata.Count > 0)
+    {
+        <div class="d-flex flex-column gap-2 py-4">
+            @Render(successMetadata, Severity.Success)
+            @Render(infoMetadata, Severity.Info)
+            @Render(errorMetadata, Severity.Error)
+        </div>
+    }
+}
+
+@code
+{
+    private RenderFragment Render<TMetadata>(List<TMetadata> metadatas, Severity severity) where TMetadata : IMessageMetadata =>
+        Render(metadatas.OfType<IMessageMetadata>().ToList(), severity);
+
+    private RenderFragment Render(List<IMessageMetadata> metadatas, Severity severity)
+    {
+        if (metadatas.Count == 0)  
+            return _ => { };
+
+        Action? dismissAction = 
+            Dismissible
+            ? () => Metadata?.RemoveAll(metadata => metadatas.Contains(metadata))
+            : () => { };
+
+        return 
+            @<MudAlert Variant="Variant.Outlined" Severity="severity" ShowCloseIcon="Dismissible" CloseIconClicked="dismissAction">
+                @foreach (var metadata in metadatas)
+                {
+                    <p>@metadata.Message</p>
+                }
+            </MudAlert>;
+    }
+}

--- a/src/Tyne.UI/src/MetadataDisplay/TyneMetadataDisplay.razor.cs
+++ b/src/Tyne.UI/src/MetadataDisplay/TyneMetadataDisplay.razor.cs
@@ -1,0 +1,16 @@
+using Microsoft.AspNetCore.Components;
+using Tyne.Results;
+
+namespace Tyne.UI;
+
+public partial class TyneMetadataDisplay
+{
+	[Parameter]
+	public bool Disabled { get; set; }
+
+	[Parameter]
+	public bool Dismissible { get; set; } = true;
+
+	[Parameter, EditorRequired]
+	public List<IMetadata>? Metadata { get; set; }
+}

--- a/src/Tyne.UI/test/MetadataDisplay/MetadataDisplayTests.cs
+++ b/src/Tyne.UI/test/MetadataDisplay/MetadataDisplayTests.cs
@@ -1,0 +1,118 @@
+using Microsoft.AspNetCore.Components.Web;
+using Tyne.Results;
+
+namespace Tyne.UI;
+
+public class MetadataDisplayTests : TestContext
+{
+	public static object[][] MessagesData() => new[]
+	{
+		// Single metadata
+		new object[] { Result.Successful(new SuccessMetadata("Example success message.")), new string[] { "Example success message." } },
+		new object[] { Result.Successful(new InfoMetadata("Example info message.")), new string[] { "Example info message." } },
+		new object[] { Result.Successful(new ErrorMetadata("Example error message.")), new string[] { "Example error message." } },
+
+		// Multiple metadatas
+		new object[] { 
+			Result.Successful(
+				   new SuccessMetadata("Example success message #1"), new SuccessMetadata("Example success message #2"),
+				   new InfoMetadata("Example info message #1"), new InfoMetadata("Example info message #2"),
+				   new ErrorMetadata("Example error message #1"), new ErrorMetadata("Example error message #2")
+			), 
+			new string[] {
+				"Example success message #1", "Example success message #2",
+				"Example info message #1", "Example info message #2",
+				"Example error message #1", "Example error message #2"
+			}
+		},
+	};
+
+	[Theory]
+	[MemberData(nameof(MessagesData))]
+	public void Enabled_ShouldShowMessages(Result<Unit> result, string[] expectedMessages)
+	{
+		// Act
+		var cut = RenderComponent<TyneMetadataDisplay>(parameters => parameters
+			.Add(metadataDisplay => metadataDisplay.Disabled, false)
+			.Add(metadataDisplay => metadataDisplay.Dismissible, false)
+			.Add(metadataDisplay => metadataDisplay.Metadata, result.Metadata)
+		);
+
+		// Assert
+		foreach (var expectedMessage in expectedMessages)
+			Assert.Contains(expectedMessage, cut.Markup);
+	}
+
+	[Theory]
+	[MemberData(nameof(MessagesData))]
+	public void Disabled_ShouldNotShowMessages(Result<Unit> result, string[] expectedMessages)
+	{
+		// Act
+		var cut = RenderComponent<TyneMetadataDisplay>(parameters => parameters
+			.Add(metadataDisplay => metadataDisplay.Disabled, true)
+			.Add(metadataDisplay => metadataDisplay.Dismissible, false)
+			.Add(metadataDisplay => metadataDisplay.Metadata, result.Metadata)
+		);
+
+		// Assert
+		foreach (var expectedMessage in expectedMessages)
+			Assert.DoesNotContain(expectedMessage, cut.Markup);
+	}
+
+	[Theory]
+	[MemberData(nameof(MessagesData))]
+	public async Task Dismissible_ShouldRemoveMetadata(Result<Unit> result, string[] _)
+	{
+		// The original metadata
+		var originalMetadata = result.Metadata.ToList();
+
+		// Arrange
+		// Clears metadata of type T from result
+		async Task ClearMessagesAsync<T>(IRenderedComponent<TyneMetadataDisplay> cut, string alertCssSelector) where T : IMessageMetadata
+		{
+			// Return if the result doesn't have this T metadata
+			var doesHaveRelevantMetadata = result.Metadata.OfType<T>().Any();
+			if (!doesHaveRelevantMetadata)
+				return;
+
+			// Find the alert component
+			var alertComponent = cut.Find(alertCssSelector);
+			Assert.NotNull(alertComponent);
+
+			// Dismiss the type of alert
+			var closeAlertButton = alertComponent.QuerySelector(".mud-alert-close button.mud-button-root");
+			Assert.NotNull(closeAlertButton);
+			await closeAlertButton!.ClickAsync(new MouseEventArgs());
+
+			// Loop over every original metadata T
+			foreach (var metadata in originalMetadata!.OfType<T>())
+			{
+				// Metadata should have been removed from Result.Metadata
+				Assert.DoesNotContain(metadata, result.Metadata);
+				// Component should have updated to not render the metadata
+				Assert.DoesNotContain(metadata.Message, cut.Markup, StringComparison.OrdinalIgnoreCase);
+			}
+		}
+
+		// Act
+		var cut = RenderComponent<TyneMetadataDisplay>(parameters => parameters
+			.Add(metadataDisplay => metadataDisplay.Disabled, false)
+			.Add(metadataDisplay => metadataDisplay.Dismissible, true)
+			.Add(metadataDisplay => metadataDisplay.Metadata, result.Metadata)
+		);
+
+		// Assert
+		// Clear messages of each type individually
+		await ClearMessagesAsync<ISuccessMetadata>(cut, ".mud-alert-outlined-success");
+		await ClearMessagesAsync<IInfoMetadata>(cut, ".mud-alert-outlined-info");
+		await ClearMessagesAsync<IErrorMetadata>(cut, ".mud-alert-outlined-error");
+
+		// Should be no message success, info, or error metadata left
+		Assert.Empty(result.Metadata.OfType<ISuccessMetadata>());
+		Assert.Empty(result.Metadata.OfType<IInfoMetadata>());
+		Assert.Empty(result.Metadata.OfType<IErrorMetadata>());
+
+		// And the component shouldn't render at all
+		Assert.Empty(cut.Markup);
+	}
+}


### PR DESCRIPTION
Designed to show basic metadata output. Includes docs page and tests.