### PR TITLE
Drop `System.Runtime.Experimental` from `6.0.2` to `6.0.0`

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,7 @@
   <PropertyGroup Label="Version settings">
     <TyneMajorVersion>1</TyneMajorVersion>
     <TyneMinorVersion>9</TyneMinorVersion>
-    <TynePatchVersion>0</TynePatchVersion>
+    <TynePatchVersion>1</TynePatchVersion>
     <Version>$(TyneMajorVersion).$(TyneMinorVersion).$(TynePatchVersion)</Version>
     <AssemblyVersion>$(Version)</AssemblyVersion>
   </PropertyGroup>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -35,7 +35,7 @@
     <PackageReference Update="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
     <PackageReference Update="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
     <PackageReference Update="MudBlazor" Version="6.0.13" />
-    <PackageReference Update="System.Runtime.Experimental" Version="6.0.2" />
+    <PackageReference Update="System.Runtime.Experimental" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup Label="Test Package Versions" Condition=" '$(IsUnitTestProject)' == 'true' ">


### PR DESCRIPTION
Fixes incredibly rare reflection issue with mismatched runtime versioning