### PR TITLE
Auditing changes

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,7 +12,7 @@
 
   <PropertyGroup Label="Version settings">
     <TyneMajorVersion>2</TyneMajorVersion>
-    <TyneMinorVersion>5</TyneMinorVersion>
+    <TyneMinorVersion>6</TyneMinorVersion>
     <TynePatchVersion>0</TynePatchVersion>
     <Version>$(TyneMajorVersion).$(TyneMinorVersion).$(TynePatchVersion)</Version>
     <AssemblyVersion>$(TyneMajorVersion).$(TyneMinorVersion).$(TynePatchVersion)</AssemblyVersion>

--- a/src/EntityFramework.ChangeAuditing/AnnotatableExtensions.cs
+++ b/src/EntityFramework.ChangeAuditing/AnnotatableExtensions.cs
@@ -1,0 +1,18 @@
+using Microsoft.EntityFrameworkCore.Infrastructure;
+
+namespace Microsoft.EntityFrameworkCore;
+
+public static class AnnotatableExtensions
+{
+    public static bool HasAnnotation<TValue>(this IReadOnlyAnnotatable annotatable, string name, Func<TValue, bool> predicate)
+    {
+        ArgumentNullException.ThrowIfNull(annotatable);
+        ArgumentNullException.ThrowIfNull(name);
+        ArgumentNullException.ThrowIfNull(predicate);
+
+        return annotatable.FindAnnotation(name)?.Value is TValue value && predicate(value);
+    }
+
+    public static bool HasFlagAnnotation(this IReadOnlyAnnotatable annotatable, string name) =>
+        annotatable.HasAnnotation<bool>(name, b => b);
+}

--- a/src/EntityFramework.ChangeAuditing/DbContextChangeAuditor.cs
+++ b/src/EntityFramework.ChangeAuditing/DbContextChangeAuditor.cs
@@ -3,7 +3,9 @@ using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
+using Microsoft.EntityFrameworkCore.Metadata;
 
 namespace Tyne.EntityFramework;
 
@@ -11,6 +13,9 @@ namespace Tyne.EntityFramework;
 internal sealed class DbContextChangeAuditor : IDbContextChangeAuditor
 {
     public const string IgnoreChangeAuditingAnnotationName = "Tyne:IgnoreChangeAuditing";
+    public const string ParentNavigationForAuditingAnnotationName = "Tyne:ParentNavigationForAuditing";
+    public const string ChildNavigationForAuditingAnnotationName = "Tyne:ChildNavigationForAuditing";
+
     private readonly ITyneUserService? _userService;
 
     public DbContextChangeAuditor(IEnumerable<ITyneUserService> userServices)
@@ -33,50 +38,113 @@ internal sealed class DbContextChangeAuditor : IDbContextChangeAuditor
     {
         var userId = _userService?.TryGetUserId();
 
-        var changeEvents = new List<DbContextChangeEvent>();
-        foreach (var entry in dbContext.ChangeTracker.Entries().Where(entry => !entry.Metadata.HasFlagAnnotation(IgnoreChangeAuditingAnnotationName)))
-        {
-            var change = new DbContextChangeEvent
+        var changeEvents = dbContext.ChangeTracker
+            .Entries()
+            .Where(entry => !entry.Metadata.HasFlagAnnotation(IgnoreChangeAuditingAnnotationName))
+            .Select(entry => new
             {
-                DateTimeUtc = DateTime.UtcNow,
-                UserId = userId,
-                Action = entry.State.ToString(),
-                EntityType = entry.Entity.GetType().Name,
-                EntityId =
-                    entry.Properties
-                    .Where(p => p.Metadata.IsPrimaryKey() && p.CurrentValue is Guid)
-                    .Select(p => p.CurrentValue)
-                    .OfType<Guid>()
-                    .FirstOrDefault(),
-                ActivityId = Activity.Current?.Id ?? string.Empty,
-                Properties = entry.Properties
-                .Where(property => entry.State is EntityState.Added or EntityState.Deleted || property.IsModified)
-                .Where(property => !property.Metadata.HasFlagAnnotation(IgnoreChangeAuditingAnnotationName))
-                .Select(property =>
+                ChangeEvent = new DbContextChangeEvent
                 {
-                    var oldValue =
-                        entry.State is EntityState.Modified or EntityState.Deleted
-                        ? JsonSerializer.Serialize(property.OriginalValue)
-                        : null;
+                    Id = Guid.NewGuid(),
+                    DateTimeUtc = DateTime.UtcNow,
+                    UserId = userId,
+                    Action = entry.State.ToString(),
+                    EntityType = entry.Entity.GetType().Name,
+                    EntityId =
+                        entry.Properties
+                        .Where(p => p.Metadata.IsPrimaryKey() && p.CurrentValue is Guid)
+                        .Select(p => p.CurrentValue)
+                        .OfType<Guid>()
+                        .FirstOrDefault(),
+                    ActivityId = Activity.Current?.Id ?? string.Empty,
+                    Properties =
+                        entry.Properties
+                        .Where(property => entry.State is EntityState.Added or EntityState.Deleted || property.IsModified)
+                        .Where(property => !property.Metadata.HasFlagAnnotation(IgnoreChangeAuditingAnnotationName))
+                        .Select(property =>
+                        {
+                            var oldValue =
+                                entry.State is EntityState.Modified or EntityState.Deleted
+                                ? JsonSerializer.Serialize(property.OriginalValue)
+                                : null;
 
-                    var newValue =
-                        entry.State is EntityState.Added or EntityState.Modified
-                        ? JsonSerializer.Serialize(property.CurrentValue)
-                        : null;
+                            var newValue =
+                                entry.State is EntityState.Added or EntityState.Modified
+                                ? JsonSerializer.Serialize(property.CurrentValue)
+                                : null;
 
-                    return new DbContextChangeEventProperty
+                            return new DbContextChangeEventProperty
+                            {
+                                ColumnName = property.Metadata.Name,
+                                OldValueJson = oldValue,
+                                NewValueJson = newValue
+                            };
+                        })
+                        .ToList(),
+                    Parents = new()
+                },
+                ParentInfos =
+                    entry.Navigations
+                    .Where(navigationEntry =>
+                        navigationEntry.Metadata.HasFlagAnnotation(ParentNavigationForAuditingAnnotationName)
+                        || navigationEntry.Metadata.Inverse?.HasFlagAnnotation(ChildNavigationForAuditingAnnotationName) == true
+                    )
+                    .Where(navigationEntry => !navigationEntry.Metadata.IsCollection)
+                    .Select(navigationEntry => new
                     {
-                        ColumnName = property.Metadata.Name,
-                        OldValueJson = oldValue,
-                        NewValueJson = newValue
-                    };
-                })
-                .ToList()
-            };
+                        Type = navigationEntry.CurrentValue?.GetType().Name ?? string.Empty,
+                        Id = TryGetForeignKey(navigationEntry)
+                    })
+                    .ToList(),
+            })
+            .ToList();
 
-            changeEvents.Add(change);
+        foreach (var changeEvent in changeEvents)
+        {
+            foreach (var parentInfo in changeEvent.ParentInfos)
+            {
+                var parentChangeEvent =
+                    changeEvents
+                    .Where(otherChangeEvent =>
+                        otherChangeEvent.ChangeEvent.EntityId == parentInfo.Id
+                        && otherChangeEvent.ChangeEvent.EntityType == parentInfo.Type
+                    )
+                    .Select(otherChangeEvent => otherChangeEvent.ChangeEvent)
+                    .FirstOrDefault();
+
+                if (parentChangeEvent is not null)
+                    changeEvent.ChangeEvent.Parents.Add(parentChangeEvent);
+            }
         }
 
-        dbContext.AddRange(changeEvents);
+        dbContext.AddRange(changeEvents.Select(changeEvent => changeEvent.ChangeEvent));
+    }
+
+    private static Guid? TryGetForeignKey(NavigationEntry navigationEntry)
+    {
+        if (navigationEntry.Metadata is not INavigation navigation)
+            return null;
+
+        if (navigation.ForeignKey.PrincipalKey.Properties.OfType<IPropertyBase>().FirstOrDefault() is not { } primaryKeyPropertyBase)
+            return null;
+
+        if (primaryKeyPropertyBase.PropertyInfo is not PropertyInfo primaryKeyPropertyInfo)
+            return null;
+
+        if (primaryKeyPropertyInfo.PropertyType != typeof(Guid))
+            return null;
+
+        try
+        {
+            if (primaryKeyPropertyInfo.GetValue(navigationEntry.CurrentValue) is not Guid foreignKeyValue)
+                return null;
+
+            return foreignKeyValue;
+        }
+        catch (TargetException)
+        {
+            // May be thrown if the navigation isn't a type we expect (e.g. a collection<T> instead of T)
+            return null;
+        }
     }
 }

--- a/src/EntityFramework.ChangeAuditing/DbContextChangeEvent.cs
+++ b/src/EntityFramework.ChangeAuditing/DbContextChangeEvent.cs
@@ -4,7 +4,6 @@ using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace Tyne.EntityFramework;
 
-[SkipChangeAuditing]
 public class DbContextChangeEvent
 {
     public Guid Id { get; set; }

--- a/src/EntityFramework.ChangeAuditing/DbContextChangeEventProperty.cs
+++ b/src/EntityFramework.ChangeAuditing/DbContextChangeEventProperty.cs
@@ -3,7 +3,6 @@ using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace Tyne.EntityFramework;
 
-[SkipChangeAuditing]
 public class DbContextChangeEventProperty
 {
     public Guid Id { get; set; }
@@ -26,6 +25,7 @@ public class DbContextChangeEventPropertyEntityTypeConfiguration : IEntityTypeCo
             .HasKey(changeEventProperty => changeEventProperty.Id);
 
         builder
+            .IgnoreChangeAuditing()
             .ToTable("_DbChangesProperties");
     }
 }

--- a/src/EntityFramework.ChangeAuditing/DbContextChangeEventRelation.cs
+++ b/src/EntityFramework.ChangeAuditing/DbContextChangeEventRelation.cs
@@ -1,0 +1,25 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Tyne.EntityFramework;
+
+public class DbContextChangeEventRelation
+{
+    public Guid? ParentId { get; set; }
+    public DbContextChangeEvent? Parent { get; set; }
+
+    public Guid? ChildId { get; set; }
+    public DbContextChangeEvent? Child { get; set; }
+}
+
+public class DbContextChangeEventParentEntityTypeConfiguration : IEntityTypeConfiguration<DbContextChangeEventRelation>
+{
+    public void Configure(EntityTypeBuilder<DbContextChangeEventRelation> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder
+            .IgnoreChangeAuditing()
+            .ToTable("_DbChangeRelations");
+    }
+}

--- a/src/EntityFramework.ChangeAuditing/EntityTypeBuilderExtensions.cs
+++ b/src/EntityFramework.ChangeAuditing/EntityTypeBuilderExtensions.cs
@@ -1,0 +1,21 @@
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Tyne.EntityFramework;
+
+namespace Microsoft.EntityFrameworkCore;
+
+public static class EntityTypeBuilderExtensions
+{
+    public static EntityTypeBuilder<TEntity> IgnoreChangeAuditing<TEntity>(
+        this EntityTypeBuilder<TEntity> entityTypeBuilder,
+        bool ignoreChangeAuditing = true
+    )
+        where TEntity : class
+    {
+        ArgumentNullException.ThrowIfNull(entityTypeBuilder);
+
+        entityTypeBuilder.HasAnnotation(DbContextChangeAuditor.IgnoreChangeAuditingAnnotationName, ignoreChangeAuditing);
+
+        return entityTypeBuilder;
+    }
+}

--- a/src/EntityFramework.ChangeAuditing/EntityTypeBuilderExtensions.cs
+++ b/src/EntityFramework.ChangeAuditing/EntityTypeBuilderExtensions.cs
@@ -18,4 +18,37 @@ public static class EntityTypeBuilderExtensions
 
         return entityTypeBuilder;
     }
+
+    public static EntityTypeBuilder<TEntity> HasAuditParent<TEntity, TNavigation>(
+        this EntityTypeBuilder<TEntity> entityTypeBuilder,
+        Expression<Func<TEntity, TNavigation?>> navigationExpression
+    )
+        where TEntity : class
+        where TNavigation : class
+    {
+        ArgumentNullException.ThrowIfNull(entityTypeBuilder);
+        ArgumentNullException.ThrowIfNull(navigationExpression);
+
+        entityTypeBuilder
+            .Navigation(navigationExpression)
+            .HasAnnotation(DbContextChangeAuditor.ParentNavigationForAuditingAnnotationName, true);
+
+        return entityTypeBuilder;
+    }
+
+    public static EntityTypeBuilder<TEntity> HasAuditChildren<TEntity, TNavigation>(
+        this EntityTypeBuilder<TEntity> entityTypeBuilder,
+        Expression<Func<TEntity, IEnumerable<TNavigation>?>> navigationExpression
+    )
+        where TEntity : class
+    {
+        ArgumentNullException.ThrowIfNull(entityTypeBuilder);
+        ArgumentNullException.ThrowIfNull(navigationExpression);
+
+        entityTypeBuilder
+            .Navigation(navigationExpression)
+            .HasAnnotation(DbContextChangeAuditor.ChildNavigationForAuditingAnnotationName, true);
+
+        return entityTypeBuilder;
+    }
 }

--- a/src/EntityFramework.ChangeAuditing/PropertyBuilderExtensions.cs
+++ b/src/EntityFramework.ChangeAuditing/PropertyBuilderExtensions.cs
@@ -1,0 +1,16 @@
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Tyne.EntityFramework;
+
+namespace Microsoft.EntityFrameworkCore;
+
+public static class PropertyBuilderExtensions
+{
+    public static PropertyBuilder<TProperty> IgnoreChangeAuditing<TProperty>(this PropertyBuilder<TProperty> propertyBuilder, bool ignoreChangeAuditing = true)
+    {
+        ArgumentNullException.ThrowIfNull(propertyBuilder);
+
+        propertyBuilder.Metadata.SetAnnotation(DbContextChangeAuditor.IgnoreChangeAuditingAnnotationName, ignoreChangeAuditing);
+
+        return propertyBuilder;
+    }
+}

--- a/src/EntityFramework.ChangeAuditing/SkipChangeAuditingAttribute.cs
+++ b/src/EntityFramework.ChangeAuditing/SkipChangeAuditingAttribute.cs
@@ -1,6 +1,0 @@
-namespace Tyne.EntityFramework;
-
-[AttributeUsage(AttributeTargets.Class)]
-public sealed class SkipChangeAuditingAttribute : Attribute
-{
-}

--- a/src/EntityFramework.UserService/EntityFramework.UserService.csproj
+++ b/src/EntityFramework.UserService/EntityFramework.UserService.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Switch from [SkipChangeAuditing] attribute to EF metadata using `.IgnoreChangeAuditing()`
- Track child/parent changes (will require a new migration to upgrade)
- Upgrade to v2.6.0