### PR TITLE
dev

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "docfx": {
-      "version": "2.75.3",
+      "version": "2.76.0",
       "commands": [
         "docfx"
       ]

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "docfx": {
-      "version": "2.70.3",
+      "version": "2.75.3",
       "commands": [
         "docfx"
       ]

--- a/.github/workflows/build-and-test-main.yml
+++ b/.github/workflows/build-and-test-main.yml
@@ -9,15 +9,18 @@ jobs:
   build-test:
     name: Build and test
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        dotnet: [ '7.0.x', '8.0.x' ]
 
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
         
-      - name: Setup .NET
+      - name: Setup .NET ${{ matrix.dotnet }}
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 7.0.x
+          dotnet-version: ${{ matrix.dotnet }}
           
       - name: Setup workloads
         run: dotnet workload install wasm-tools

--- a/.github/workflows/build-and-test-main.yml
+++ b/.github/workflows/build-and-test-main.yml
@@ -9,9 +9,6 @@ jobs:
   build-test:
     name: Build and test
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        dotnet: [ '7.0.x', '8.0.x' ]
 
     steps:
       - name: Checkout repo
@@ -20,7 +17,10 @@ jobs:
       - name: Setup .NET ${{ matrix.dotnet }}
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: ${{ matrix.dotnet }}
+          dotnet-version: |
+            7.x
+            8.x
+            9.x
           
       - name: Setup workloads
         run: dotnet workload install wasm-tools

--- a/.github/workflows/build-and-test-pr.yml
+++ b/.github/workflows/build-and-test-pr.yml
@@ -7,15 +7,18 @@ jobs:
   build-test:
     name: Build and test
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        dotnet: [ '7.0.x', '8.0.x' ]
 
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
         
-      - name: Setup .NET
+      - name: Setup .NET ${{ matrix.dotnet }}
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 7.0.x
+          dotnet-version: ${{ matrix.dotnet }}
           
       - name: Setup workloads
         run: dotnet workload install wasm-tools

--- a/.github/workflows/build-and-test-pr.yml
+++ b/.github/workflows/build-and-test-pr.yml
@@ -7,9 +7,6 @@ jobs:
   build-test:
     name: Build and test
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        dotnet: [ '7.0.x', '8.0.x' ]
 
     steps:
       - name: Checkout repo
@@ -18,7 +15,10 @@ jobs:
       - name: Setup .NET ${{ matrix.dotnet }}
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: ${{ matrix.dotnet }}
+          dotnet-version: |
+            7.x
+            8.x
+            9.x
           
       - name: Setup workloads
         run: dotnet workload install wasm-tools

--- a/.github/workflows/publish-all.yml
+++ b/.github/workflows/publish-all.yml
@@ -28,11 +28,12 @@ jobs:
           ref: 'refs/tags/v${{ env.PACKAGE_VERSION }}'
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v2
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            7.0.x
-            8.0.x
+            7.x
+            8.x
+            9.x
           
       - name: Setup workloads
         run: dotnet workload install wasm-tools

--- a/.github/workflows/publish-all.yml
+++ b/.github/workflows/publish-all.yml
@@ -30,7 +30,9 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: 7.0.x
+          dotnet-version: |
+            7.0.x
+            8.0.x
           
       - name: Setup workloads
         run: dotnet workload install wasm-tools

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -37,11 +37,12 @@ jobs:
           ref: '${{ env.GITHUB_REF }}'
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v2
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            7.0.x
-            8.0.x
+            7.x
+            8.x
+            9.x
 
       - name: Setup workloads
         run: dotnet workload install wasm-tools

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -39,7 +39,9 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: 7.0.x
+          dotnet-version: |
+            7.0.x
+            8.0.x
 
       - name: Setup workloads
         run: dotnet workload install wasm-tools

--- a/docs/.docs.csproj
+++ b/docs/.docs.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <!-- Multi-target .NET7 and .NET8. -->
+    <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
     <!-- This project doesn't contain any .NET code. -->
     <EnableNETAnalyzers>false</EnableNETAnalyzers>
   </PropertyGroup>

--- a/docs/.docs.csproj
+++ b/docs/.docs.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.Build.NoTargets">
 
   <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
     <!-- This project doesn't contain any .NET code. -->
     <EnableNETAnalyzers>false</EnableNETAnalyzers>
   </PropertyGroup>

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <PropertyGroup Label="Conventions">
-    <TargetFrameworks>net7.0</TargetFrameworks>
+    <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
     <LangVersion>preview</LangVersion>
     <Features>$(Features);strict</Features>
     <Nullable>enable</Nullable>

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -11,7 +11,6 @@
   </PropertyGroup>
 
   <PropertyGroup Label="Conventions">
-    <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
     <LangVersion>preview</LangVersion>
     <Features>$(Features);strict</Features>
     <Nullable>enable</Nullable>

--- a/eng/Build.props
+++ b/eng/Build.props
@@ -16,7 +16,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <AccelerateBuildsInVisualStudio>true</AccelerateBuildsInVisualStudio>
-    <ArtifactsPath>$(MSBuildThisFileDirectory)artifacts</ArtifactsPath>
+    <ArtifactsPath>$(MSBuildThisFileDirectory)../artifacts</ArtifactsPath>
   </PropertyGroup>
 
   <!--

--- a/eng/Build.targets
+++ b/eng/Build.targets
@@ -10,31 +10,48 @@
     This doesn't *add* these packages to every project, instead it ensures that
     every package set up to use one of these is using the same unified version.
   -->
-  <ItemGroup Label="Package versions">
-    <PackageReference Update="FluentValidation" Version="11.8.1" />
+  <ItemGroup Label="Package versions (any .NET version)">
+    <PackageReference Update="FluentValidation" Version="11.9.0" />
     <PackageReference Update="MediatR" Version="12.2.0" />
     <PackageReference Update="MediatR.Contracts" Version="2.0.1" />
-    <PackageReference Update="Microsoft.AspNetCore.Components" Version="7.0.14" />
-    <PackageReference Update="Microsoft.EntityFrameworkCore" Version="7.0.8" />
-    <PackageReference Update="Microsoft.EntityFrameworkCore.Relational" Version="7.0.8" />
+    <PackageReference Update="MudBlazor" Version="6.19.1" />
+  </ItemGroup>
+
+  <!-- Same as above, but for test packages. -->
+  <ItemGroup Label="Test package versions (any .NET version)">
+    <PackageReference Update="bunit" Version="1.27.17" />
+    <PackageReference Update="coverlet.collector" Version="6.0.2" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Update="NSubstitute" Version="5.1.0" />
+    <PackageReference Update="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
+    <PackageReference Update="xunit" Version="2.7.0" />
+    <PackageReference Update="xunit.runner.visualstudio" Version="2.5.7" />
+  </ItemGroup>
+
+  <!-- .NET 7 -->
+  <ItemGroup Label="Package versions (.NET 7)" Condition=" '$(TargetFramework)' == 'net7.0' ">
+    <PackageReference Update="Microsoft.AspNetCore.Components" Version="7.0.17" />
+    <PackageReference Update="Microsoft.EntityFrameworkCore" Version="7.0.17" />
+    <PackageReference Update="Microsoft.EntityFrameworkCore.Relational" Version="7.0.17" />
     <PackageReference Update="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
     <PackageReference Update="Microsoft.Extensions.Configuration.Binder" Version="7.0.4" />
     <PackageReference Update="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
     <PackageReference Update="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
     <PackageReference Update="Microsoft.Extensions.Logging.Abstractions" Version="7.0.1" />
     <PackageReference Update="Microsoft.Extensions.Options" Version="7.0.1" />
-    <PackageReference Update="MudBlazor" Version="6.11.1" />
   </ItemGroup>
 
-  <!-- Same as above, but for test packages. -->
-  <ItemGroup Label="Test package versions">
-    <PackageReference Update="bunit" Version="1.21.9" />
-    <PackageReference Update="coverlet.collector" Version="6.0.0" />
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Update="NSubstitute" Version="5.0.0" />
-    <PackageReference Update="NSubstitute.Analyzers.CSharp" Version="1.0.16" />
-    <PackageReference Update="xunit" Version="2.4.2" />
-    <PackageReference Update="xunit.runner.visualstudio" Version="2.4.5" />
+  <!-- .NET 8 -->
+  <ItemGroup Label="Package versions (.NET 8)" Condition=" '$(TargetFramework)' == 'net8.0' ">
+    <PackageReference Update="Microsoft.AspNetCore.Components" Version="8.0.3" />
+    <PackageReference Update="Microsoft.EntityFrameworkCore" Version="8.0.3" />
+    <PackageReference Update="Microsoft.EntityFrameworkCore.Relational" Version="8.0.3" />
+    <PackageReference Update="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+    <PackageReference Update="Microsoft.Extensions.Configuration.Binder" Version="8.0.1" />
+    <PackageReference Update="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
+    <PackageReference Update="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
+    <PackageReference Update="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+    <PackageReference Update="Microsoft.Extensions.Options" Version="8.0.2" />
   </ItemGroup>
 
   <!-- These warnings can be ignored for non-shipped code. -->

--- a/eng/Build.targets
+++ b/eng/Build.targets
@@ -54,6 +54,19 @@
     <PackageReference Update="Microsoft.Extensions.Options" Version="8.0.2" />
   </ItemGroup>
 
+  <!-- .NET 9 -->
+  <ItemGroup Label="Package versions (.NET 9)" Condition=" '$(TargetFramework)' == 'net9.0' ">
+    <PackageReference Update="Microsoft.AspNetCore.Components" Version="9.0.0-preview.2.24128.4" />
+    <PackageReference Update="Microsoft.EntityFrameworkCore" Version="9.0.0-preview.2.24128.4" />
+    <PackageReference Update="Microsoft.EntityFrameworkCore.Relational" Version="9.0.0-preview.2.24128.4" />
+    <PackageReference Update="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.0-preview.2.24128.5" />
+    <PackageReference Update="Microsoft.Extensions.Configuration.Binder" Version="9.0.0-preview.2.24128.5" />
+    <PackageReference Update="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0-preview.2.24128.5" />
+    <PackageReference Update="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.0-preview.2.24128.5" />
+    <PackageReference Update="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0-preview.2.24128.5" />
+    <PackageReference Update="Microsoft.Extensions.Options" Version="9.0.0-preview.2.24128.5" />
+  </ItemGroup>
+
   <!-- These warnings can be ignored for non-shipped code. -->
   <PropertyGroup Label="Warnings and errors" Condition=" !$(IsPackable) ">
     <!--

--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -1,6 +1,8 @@
 <Project>
 
   <PropertyGroup>
+    <!-- Multi-target .NET7 and .NET8. -->
+    <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
     <!-- Mark the project as a package. -->
     <IsPackable>true</IsPackable>
     <!-- Ensure this is marked as a CI build if we're executing on a GitHub action. -->

--- a/eng/Packages.props
+++ b/eng/Packages.props
@@ -1,8 +1,8 @@
 <Project>
 
   <PropertyGroup>
-    <!-- Multi-target .NET7 and .NET8. -->
-    <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
+    <!-- Multi-target .NET releases -->
+    <TargetFrameworks>net7.0;net8.0;net9.0</TargetFrameworks>
     <!-- Mark the project as a package. -->
     <IsPackable>true</IsPackable>
     <!-- Ensure this is marked as a CI build if we're executing on a GitHub action. -->

--- a/eng/Tests.props
+++ b/eng/Tests.props
@@ -1,5 +1,10 @@
 <Project>
 
+  <PropertyGroup>
+    <!-- Multi-target .NET7 and .NET8. -->
+    <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
+  </PropertyGroup>
+  
   <!-- Configures global usings for very common namespaces in test projects. -->
   <ItemGroup Label="Global usings">
     <Using Include="NSubstitute" />

--- a/eng/Tests.props
+++ b/eng/Tests.props
@@ -1,8 +1,8 @@
 <Project>
 
   <PropertyGroup>
-    <!-- Multi-target .NET7 and .NET8. -->
-    <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
+    <!-- Multi-target .NET releases -->
+    <TargetFrameworks>net7.0;net8.0;net9.0</TargetFrameworks>
   </PropertyGroup>
   
   <!-- Add common testing packages. -->

--- a/eng/Tests.props
+++ b/eng/Tests.props
@@ -5,6 +5,19 @@
     <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
   </PropertyGroup>
   
+  <!-- Add common testing packages. -->
+  <ItemGroup>
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="NSubstitute.Analyzers.CSharp" PrivateAssets="all" />
+    <PackageReference Include="xunit" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(IsTestProject)' == 'true' ">
+    <PackageReference Include="coverlet.collector" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" />
+  </ItemGroup>
+
   <!-- Configures global usings for very common namespaces in test projects. -->
   <ItemGroup Label="Global usings">
     <Using Include="NSubstitute" />

--- a/example/Client/Example.Client.csproj
+++ b/example/Client/Example.Client.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
   
   <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>TyneAerospaceClient</AssemblyName>
     <RootNamespace>Tyne.Aerospace.Client</RootNamespace>
   </PropertyGroup>
@@ -29,9 +30,9 @@
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.9.0" />
     <PackageReference Include="Humanizer.Core" Version="2.14.1" />
     <PackageReference Include="MediatR" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="7.0.17" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.17" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="MudBlazor" />
   </ItemGroup>
   

--- a/example/Client/Example.Client.csproj
+++ b/example/Client/Example.Client.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
   
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
     <AssemblyName>TyneAerospaceClient</AssemblyName>
     <RootNamespace>Tyne.Aerospace.Client</RootNamespace>
   </PropertyGroup>
@@ -27,13 +26,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.5.2" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.9.0" />
     <PackageReference Include="Humanizer.Core" Version="2.14.1" />
-    <PackageReference Include="MediatR" Version="12.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="7.0.13" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.8" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="7.0.8" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.15" />
+    <PackageReference Include="MediatR" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="7.0.17" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.17" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
     <PackageReference Include="MudBlazor" />
   </ItemGroup>
   

--- a/example/Client/Features/Systems/Filtering/SelectUpdateValues/OrbitalTypeSelectValue.cs
+++ b/example/Client/Features/Systems/Filtering/SelectUpdateValues/OrbitalTypeSelectValue.cs
@@ -33,24 +33,24 @@ public class OrbitalTypeSelectValue<TRequest> : TyneFilterSelectSingleValueBase<
         // This content could be loaded from an API instead
         List<IFilterSelectItem<string?>> orbitalTypes = OrbitalBody switch
         {
-            OrbitalBody.Earth => new()
-            {
+            OrbitalBody.Earth =>
+            [
                 FilterSelectItem.Create("LEO", "Low earth"),
                 FilterSelectItem.Create("SSO", "Sun-synchronous"),
                 FilterSelectItem.Create("GEO", "Geostationary"),
-            },
-            OrbitalBody.Moon => new()
-            {
+            ],
+            OrbitalBody.Moon =>
+            [
                 FilterSelectItem.Create("LLO", "Low lunar"),
                 FilterSelectItem.Create("NRHO", "Near-rectilinear halo"),
                 FilterSelectItem.Create("DRO", "Distant retrograde")
-            },
-            _ => new()
-            {
+            ],
+            _ =>
+            [
                 FilterSelectItem.Create("LMO", "Low mars"),
                 FilterSelectItem.Create("AEO", "Areostationary"),
                 FilterSelectItem.Create("ASO", "Areosynchronous"),
-            }
+            ]
         };
 
         return Task.FromResult(orbitalTypes);

--- a/example/Client/_Imports.razor
+++ b/example/Client/_Imports.razor
@@ -4,7 +4,6 @@
 @using Microsoft.AspNetCore.Components.Routing
 @using Microsoft.AspNetCore.Components.Web
 @using Microsoft.AspNetCore.Components.Web.Virtualization
-@using Microsoft.AspNetCore.Components.WebAssembly.Http
 @using Microsoft.JSInterop
 @using MudBlazor
 @using Tyne.Blazor

--- a/example/Host.Server/Example.Host.Server.csproj
+++ b/example/Host.Server/Example.Host.Server.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>TyneAerospaceClient.ServerHost</AssemblyName>
     <RootNamespace>Tyne.Aerospace.Host.Server</RootNamespace>
     <!-- Prevents dotnet pack from trying to pack this, and then warning when it can't -->

--- a/example/Host.Server/Example.Host.Server.csproj
+++ b/example/Host.Server/Example.Host.Server.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
     <AssemblyName>TyneAerospaceClient.ServerHost</AssemblyName>
     <RootNamespace>Tyne.Aerospace.Host.Server</RootNamespace>
     <!-- Prevents dotnet pack from trying to pack this, and then warning when it can't -->

--- a/example/Host.Wasm/Example.Host.Wasm.csproj
+++ b/example/Host.Wasm/Example.Host.Wasm.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>TyneAerospaceClient.WasmHost</AssemblyName>
     <RootNamespace>Tyne.Aerospace.Host.Wasm</RootNamespace>
     <!-- Allows the Roslyn compiler to code gen with pointers for JS interop. -->

--- a/example/Host.Wasm/Example.Host.Wasm.csproj
+++ b/example/Host.Wasm/Example.Host.Wasm.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
     <AssemblyName>TyneAerospaceClient.WasmHost</AssemblyName>
     <RootNamespace>Tyne.Aerospace.Host.Wasm</RootNamespace>
     <!-- Allows the Roslyn compiler to code gen with pointers for JS interop. -->
@@ -16,8 +15,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.8" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="7.0.8" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.17" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="7.0.17" PrivateAssets="all" />
   </ItemGroup>
 
   <PropertyGroup Label="Warnings and Errors">

--- a/example/SourceRef.SourceGenerators/Components/ComponentSourceFormatter.cs
+++ b/example/SourceRef.SourceGenerators/Components/ComponentSourceFormatter.cs
@@ -2,13 +2,15 @@ namespace Tyne.SourceRef.SourceGenerators.Components;
 
 internal static class ComponentSourceFormatter
 {
+    private static readonly string[] FileContentsSplit = ["\n"];
+
     /// <summary>
     ///     Formats the source code of a Razor component.
     /// </summary>
     public static string Format(string contents)
     {
         // First split the source by newline, keep the empty entries
-        var split = contents.Replace("\r\n", "\n").Split(new string[] { "\n" }, StringSplitOptions.None);
+        var split = contents.Replace("\r\n", "\n").Split(FileContentsSplit, StringSplitOptions.None);
 
         // Strip component directives
         var stripped = StripComponentDirectives(split);

--- a/example/SourceRef.SourceGenerators/SourceRef.SourceGenerators.csproj
+++ b/example/SourceRef.SourceGenerators/SourceRef.SourceGenerators.csproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <!-- Disable building for other .NET versions -->
-    <TargetFrameworks></TargetFrameworks>
     <AssemblyName>Tyne.SourceRef.SourceGenerators</AssemblyName>
     <RootNamespace>Tyne.SourceRef.SourceGenerators</RootNamespace>
   </PropertyGroup>

--- a/example/SourceRef.SourceGenerators/Types/TypeSourceFormatter.cs
+++ b/example/SourceRef.SourceGenerators/Types/TypeSourceFormatter.cs
@@ -2,13 +2,15 @@ namespace Tyne.SourceRef.SourceGenerators.Types;
 
 internal static class TypeSourceFormatter
 {
+    private static readonly string[] FileContentsSplit = ["\n"];
+
     /// <summary>
     ///     Formats the source code of a type.
     /// </summary>
     public static string Format(string contents)
     {
         // First split the source by newline, keep the empty entries
-        var split = contents.Replace("\r\n", "\n").Split(new string[] { "\n" }, StringSplitOptions.None);
+        var split = contents.Replace("\r\n", "\n").Split(FileContentsSplit, StringSplitOptions.None);
 
         // Calculate the minimum indentation - we use this do outdent the source
         // This is especially useful for nested types to avoid the source all being left-padded

--- a/example/SourceRef.SourceGenerators/Types/TypeSourceInfoSyntaxReceiver.cs
+++ b/example/SourceRef.SourceGenerators/Types/TypeSourceInfoSyntaxReceiver.cs
@@ -6,7 +6,7 @@ namespace Tyne.SourceRef.SourceGenerators.Types;
 // Visits type declarations and creates SourceInfos
 internal sealed class TypeSourceInfoSyntaxReceiver : ISyntaxReceiver
 {
-    public List<SourceInfo> TypeSources { get; } = new();
+    public List<SourceInfo> TypeSources { get; } = [];
 
     public void OnVisitSyntaxNode(SyntaxNode syntaxNode)
     {

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.200",
+    "version": "9.0.0",
     "rollForward": "latestFeature"
   },
   "msbuild-sdks": {

--- a/global.json
+++ b/global.json
@@ -4,6 +4,6 @@
     "rollForward": "latestFeature"
   },
   "msbuild-sdks": {
-    "Microsoft.Build.NoTargets": "3.7.0"
+    "Microsoft.Build.NoTargets": "3.7.56"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.200",
+    "version": "8.0.200",
     "rollForward": "latestFeature"
   },
   "msbuild-sdks": {

--- a/src/AspNetCore/AspNetCore.csproj
+++ b/src/AspNetCore/AspNetCore.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
     <AssemblyName>Tyne.AspNetCore</AssemblyName>
     <RootNamespace>Tyne.AspNetCore</RootNamespace>
   </PropertyGroup>

--- a/src/AspNetCore/Endpoints/NotFoundEndpointExtensions.cs
+++ b/src/AspNetCore/Endpoints/NotFoundEndpointExtensions.cs
@@ -4,15 +4,35 @@ using Microsoft.AspNetCore.Routing;
 
 namespace Microsoft.AspNetCore.Builder;
 
+[SuppressMessage("Info Code Smell", "S1133: Deprecated code should be removed.", Justification = "Methods are deprecated to allow for a graceful transition. They will be removed in a future version.")]
 public static class NotFoundEndpointExtensions
 {
+    private const string ObsoleteDiagnosticMessage = $"Use {nameof(MapFallbackToNotFound)} instead.";
+    private const string ObsoleteDiagnosticId = "TYNEOLD";
+
+    [Obsolete(message: ObsoleteDiagnosticMessage, DiagnosticId = ObsoleteDiagnosticId)]
     public static IEndpointConventionBuilder MapNotFoundFallback(this IEndpointRouteBuilder app) =>
-        MapNotFoundFallback(app, "{*path:nonfile}");
+        MapFallbackToNotFound(app);
 
+    [Obsolete(message: ObsoleteDiagnosticMessage, DiagnosticId = ObsoleteDiagnosticId)]
     public static IEndpointConventionBuilder MapNotFoundFallback(this IEndpointRouteBuilder app, [StringSyntax("Route")] string pattern) =>
-        MapNotFoundFallback(app, pattern, _ => { });
+        MapFallbackToNotFound(app, pattern);
 
-    public static IEndpointConventionBuilder MapNotFoundFallback(this IEndpointRouteBuilder app, [StringSyntax("Route")] string pattern, Action<HttpContext> handler)
+    [Obsolete(message: ObsoleteDiagnosticMessage, DiagnosticId = ObsoleteDiagnosticId)]
+    public static IEndpointConventionBuilder MapNotFoundFallback(this IEndpointRouteBuilder app, [StringSyntax("Route")] string pattern, Action<HttpContext> handler) =>
+        MapFallbackToNotFound(app, pattern, handler);
+
+    [Obsolete(message: ObsoleteDiagnosticMessage, DiagnosticId = ObsoleteDiagnosticId)]
+    public static IEndpointConventionBuilder MapNotFoundFallback(this IEndpointRouteBuilder app, [StringSyntax("Route")] string pattern, Func<HttpContext, Task> handler) =>
+        MapFallbackToNotFound(app, pattern, handler);
+
+    public static IEndpointConventionBuilder MapFallbackToNotFound(this IEndpointRouteBuilder app) =>
+        MapFallbackToNotFound(app, "{*path:nonfile}");
+
+    public static IEndpointConventionBuilder MapFallbackToNotFound(this IEndpointRouteBuilder app, [StringSyntax("Route")] string pattern) =>
+        MapFallbackToNotFound(app, pattern, _ => { });
+
+    public static IEndpointConventionBuilder MapFallbackToNotFound(this IEndpointRouteBuilder app, [StringSyntax("Route")] string pattern, Action<HttpContext> handler)
     {
         ArgumentNullException.ThrowIfNull(handler);
 
@@ -22,10 +42,10 @@ public static class NotFoundEndpointExtensions
             return Task.CompletedTask;
         }
 
-        return MapNotFoundFallback(app, pattern, AsyncHandler);
+        return MapFallbackToNotFound(app, pattern, AsyncHandler);
     }
 
-    public static IEndpointConventionBuilder MapNotFoundFallback(this IEndpointRouteBuilder app, [StringSyntax("Route")] string pattern, Func<HttpContext, Task> handler)
+    public static IEndpointConventionBuilder MapFallbackToNotFound(this IEndpointRouteBuilder app, [StringSyntax("Route")] string pattern, Func<HttpContext, Task> handler)
     {
         ArgumentNullException.ThrowIfNull(app);
         ArgumentException.ThrowIfNullOrEmpty(pattern);

--- a/src/AspNetCore/Routing/RouteAuthorisationOptions.cs
+++ b/src/AspNetCore/Routing/RouteAuthorisationOptions.cs
@@ -4,7 +4,7 @@ namespace Tyne.AspNetCore.Routing;
 
 internal sealed class RouteAuthorisationOptions : IRouteAuthorisationOptions
 {
-    internal List<RouteAuthorisation> RouteAuthorisations { get; } = new();
+    internal List<RouteAuthorisation> RouteAuthorisations { get; } = [];
 
     public IRouteAuthorisationOptions AuthoriseRoute(Func<HttpContext, bool> authoriseWhen, bool shouldHandleUnauthorised, params string[] policies)
     {

--- a/src/Blazor/Blazor.csproj
+++ b/src/Blazor/Blazor.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
     <AssemblyName>Tyne.Blazor</AssemblyName>
     <RootNamespace>Tyne.Blazor</RootNamespace>
   </PropertyGroup>

--- a/src/Blazor/Components/Environment/Environment.cs
+++ b/src/Blazor/Components/Environment/Environment.cs
@@ -45,7 +45,7 @@ public partial class Environment : ComponentBase
     [Parameter, EditorRequired]
     public string Filter { get; set; } = string.Empty;
 
-    private string[] _environmentNormalisedNameFilters = Array.Empty<string>();
+    private string[] _environmentNormalisedNameFilters = [];
 
     private string _environmentName = string.Empty;
     private string _environmentNormalisedName = string.Empty;

--- a/src/Blazor/Components/Filtering/Context/FilterContextBatchUpdateQueue.cs
+++ b/src/Blazor/Components/Filtering/Context/FilterContextBatchUpdateQueue.cs
@@ -25,7 +25,7 @@ internal sealed class FilterContextBatchUpdateQueue<TRequest>
     ///     Because of this, multiple calls in quick succession (such as a batch update) are likely to fail as the current URL will not have updated yet.
     /// </remarks>
     /// <seealso href="https://github.com/dotnet/aspnetcore/blob/main/src/Components/WebAssembly/WebAssembly/src/Services/WebAssemblyNavigationManager.cs#L57"/>
-    public Dictionary<string, object?> PersistenceParameterQueue { get; } = new();
+    public Dictionary<string, object?> PersistenceParameterQueue { get; } = [];
 
     public FilterContextBatchUpdateQueue(TyneFilterContext<TRequest> filterContext)
     {

--- a/src/Blazor/Components/Filtering/Context/TyneFilterContext.cs
+++ b/src/Blazor/Components/Filtering/Context/TyneFilterContext.cs
@@ -54,8 +54,8 @@ public sealed class TyneFilterContext<TRequest> : IFilterContext<TRequest>, IDis
     public IUrlPersistenceService Persistence { get; }
 
     // Attached handles for values and controllers
-    private readonly Dictionary<TyneKey, FilterValueHandle<TRequest>> _valueHandles = new();
-    private readonly Dictionary<TyneKey, HashSet<FilterControllerHandle>> _controllerHandles = new();
+    private readonly Dictionary<TyneKey, FilterValueHandle<TRequest>> _valueHandles = [];
+    private readonly Dictionary<TyneKey, HashSet<FilterControllerHandle>> _controllerHandles = [];
 
     /// <summary>
     ///     Constructs an instance of <see cref="TyneFilterContext{TRequest}"/>.
@@ -398,7 +398,7 @@ public sealed class TyneFilterContext<TRequest> : IFilterContext<TRequest>, IDis
 
         // Create a new set of handles if one hasn't already been attached
         if (!_controllerHandles.TryGetValue(key, out var controllerHandles))
-            controllerHandles = _controllerHandles[key] = new();
+            controllerHandles = _controllerHandles[key] = [];
 
         var controllerHandle = new FilterControllerHandle<TRequest, TValue>(this, key, filterValue, controller);
         controllerHandles.Add(controllerHandle);

--- a/src/Blazor/Components/Filtering/Controllers/Range/DateTime/TyneDateRangeFilterController.razor.cs
+++ b/src/Blazor/Components/Filtering/Controllers/Range/DateTime/TyneDateRangeFilterController.razor.cs
@@ -7,7 +7,7 @@ namespace Tyne.Blazor.Filtering.Controllers;
 ///     A controller which attaches to a minimum and maximum <see cref="DateTime"/> property.
 /// </summary>
 /// <inheritdoc/>
-public partial class TyneDateRangeFilterController<TRequest>
+public partial class TyneDateRangeFilterController<TRequest> : TyneMinMaxFilterController<TRequest, DateTime?>
 {
     /// <summary>
     ///     A label which the <see cref="MudDateRangePicker"/> should use.

--- a/src/Blazor/Components/Filtering/Controllers/Select/Multi/TyneMultiSelectFilterControllerBase.cs
+++ b/src/Blazor/Components/Filtering/Controllers/Select/Multi/TyneMultiSelectFilterControllerBase.cs
@@ -46,7 +46,7 @@ public abstract partial class TyneMultiSelectFilterControllerBase<TRequest, TVal
         if (newValue is not HashSet<TValue> hashSet)
         {
             if (newValue is null)
-                hashSet = new();
+                hashSet = [];
             else
                 hashSet = new(newValue);
         }
@@ -71,7 +71,7 @@ public abstract partial class TyneMultiSelectFilterControllerBase<TRequest, TVal
     ///     </para>
     /// </remarks>
     protected Task SetValueAsync(HashSet<TValue>? newValue) =>
-        Handle.Filter.SetValueAsync(newValue ?? new());
+        Handle.Filter.SetValueAsync(newValue ?? []);
 
     /// <summary>
     ///     Adds <paramref name="item"/> to the selected filter value <see cref="HashSet{T}"/>.
@@ -80,7 +80,7 @@ public abstract partial class TyneMultiSelectFilterControllerBase<TRequest, TVal
     /// <returns>A <see cref="Task"/> representing the value being added.</returns>
     protected Task AddValueAsync(TValue item)
     {
-        var currentValue = Handle.Filter.Value ?? new HashSet<TValue>();
+        var currentValue = Handle.Filter.Value ?? [];
         if (item is not null && currentValue.Contains(item))
             return Task.CompletedTask;
 

--- a/src/Blazor/Components/Filtering/Controllers/Simple/TyneStringFilterController.razor.cs
+++ b/src/Blazor/Components/Filtering/Controllers/Simple/TyneStringFilterController.razor.cs
@@ -11,7 +11,7 @@ namespace Tyne.Blazor.Filtering.Controllers;
 /// <remarks>
 ///     This controller renders as a <see cref="MudTextField{T}"/>.
 /// </remarks>
-public partial class TyneStringFilterController<TRequest>
+public partial class TyneStringFilterController<TRequest> : TyneFilterControllerBase<TRequest, string>
 {
     /// <summary>
     ///     A class to apply to the rendered <see cref="MudTextField{T}"/>.

--- a/src/Blazor/Components/Filtering/Values/Select/TyneFilterSelectValue.cs
+++ b/src/Blazor/Components/Filtering/Values/Select/TyneFilterSelectValue.cs
@@ -12,7 +12,7 @@ public abstract class TyneFilterSelectValue<TRequest, TValue, TSelectValue> : Ty
     [Parameter, EditorRequired]
     public RenderFragment Values { get; set; } = EmptyRenderFragment.Instance;
 
-    private readonly HashSet<ItemHandle> _selectItemHandles = new();
+    private readonly HashSet<ItemHandle> _selectItemHandles = [];
 
     // Used to force LoadAvailableValuesAsync to wait for Values to have rendered
     // so that the specified values can attach themselves to this instance.

--- a/src/Blazor/Components/Forms/TyneFormBase.cs
+++ b/src/Blazor/Components/Forms/TyneFormBase.cs
@@ -28,7 +28,7 @@ public abstract class TyneFormBase<TInput, TModel> : ComponentBase, ITyneForm<TM
         _onInitialised = _initialiseTaskSource.Task;
     }
 
-    private List<FormUpdatedCallback> FormUpdatedCallbacks { get; } = new();
+    private List<FormUpdatedCallback> FormUpdatedCallbacks { get; } = [];
     public IDisposable Attach(FormUpdatedCallback formUpdatedCallback)
     {
         FormUpdatedCallbacks.Add(formUpdatedCallback);

--- a/src/Blazor/Components/Forms/TyneFormBase.cs
+++ b/src/Blazor/Components/Forms/TyneFormBase.cs
@@ -117,9 +117,16 @@ public abstract class TyneFormBase<TInput, TModel> : ComponentBase, ITyneForm<TM
         await UpdateStateAsync(FormState.Loading).ConfigureAwait(true);
 
         // Cancel any other existing openings
-        _openingCancellationTokenSource?.Cancel();
-        _openingCancellationTokenSource?.Dispose();
-        _openingCancellationTokenSource = null;
+        if (_openingCancellationTokenSource is CancellationTokenSource openingCts)
+        {
+#if NET8_0_OR_GREATER
+        await openingCts.CancelAsync().ConfigureAwait(true);
+#else
+            openingCts.Cancel();
+#endif
+            openingCts.Dispose();
+            _openingCancellationTokenSource = null;
+        }
 
         // Set up our opening
         _openingCancellationTokenSource = new();
@@ -244,9 +251,19 @@ public abstract class TyneFormBase<TInput, TModel> : ComponentBase, ITyneForm<TM
         if (shouldClose)
         {
             await UpdateStateAsync(FormState.Closed).ConfigureAwait(true);
-            _openingCancellationTokenSource?.Cancel();
-            _openingCancellationTokenSource?.Dispose();
-            _openingCancellationTokenSource = null;
+
+            // Cancel any other existing openings
+            if (_openingCancellationTokenSource is CancellationTokenSource openingCts)
+            {
+#if NET8_0_OR_GREATER
+                await openingCts.CancelAsync().ConfigureAwait(true);
+#else
+                openingCts.Cancel();
+#endif
+                openingCts.Dispose();
+                _openingCancellationTokenSource = null;
+            }
+
             Model = default;
             OpenResult = null;
             SaveResult = null;

--- a/src/Blazor/Components/Forms/Validation/TyneErrorDisplay.razor
+++ b/src/Blazor/Components/Forms/Validation/TyneErrorDisplay.razor
@@ -2,7 +2,7 @@
 
 <MudAlert Severity="Severity ?? MudBlazor.Severity.Error">
     @Error.Message
-    @if (Error.Code is not 0)
+    @if (IncludeCode && Error.Code != Tyne.Error.Default.Code)
     {
         <text> (@Error.Code)</text>
     }
@@ -15,6 +15,9 @@
 
     [Parameter]
     public Severity? Severity { get; set; }
+
+    [Parameter]
+    public bool IncludeCode { get; set; } = true;
 
     protected override void OnParametersSet()
     {

--- a/src/Blazor/Components/Forms/Validation/TyneFormRootFluentValidator.cs
+++ b/src/Blazor/Components/Forms/Validation/TyneFormRootFluentValidator.cs
@@ -11,7 +11,7 @@ public class TyneFormRootFluentValidator<TModel>
     [Parameter]
     public RenderFragment ChildContent { get; set; } = EmptyRenderFragment.Instance;
 
-    private readonly HashSet<ITyneFormFluentValidator> _nestedValidators = new();
+    private readonly HashSet<ITyneFormFluentValidator> _nestedValidators = [];
 
     protected override void OnInitialized()
     {

--- a/src/Blazor/Components/Table/Columns/TyneColumnPopoverHeaderBase.razor.cs
+++ b/src/Blazor/Components/Table/Columns/TyneColumnPopoverHeaderBase.razor.cs
@@ -7,7 +7,7 @@ namespace Tyne.Blazor.Tables.Columns;
 ///     Renders a <see cref="MudTh"/> containing <see cref="Header"/>, which has a button to open a popover with <see cref="Content"/> in.
 /// </summary>
 /// <typeparam name="TResponse">The type of response.</typeparam>
-public abstract partial class TyneColumnPopoverHeaderBase<TResponse>
+public abstract partial class TyneColumnPopoverHeaderBase<TResponse> : ComponentBase
 {
     /// <summary>
     ///     <see langword="true"/> if the column is being actively filtered; otherwise, <see langword="false"/>.

--- a/src/Blazor/Components/Table/TyneTableBase.razor.cs
+++ b/src/Blazor/Components/Table/TyneTableBase.razor.cs
@@ -22,6 +22,8 @@ namespace Tyne.Blazor.Tables;
 [CascadingTypeParameter(nameof(TRequest))]
 [CascadingTypeParameter(nameof(TResponse))]
 public abstract partial class TyneTableBase<TRequest, TResponse>
+    : MudTable<TResponse>, ITyneTable, IDisposable
+    where TRequest : ISearchQuery, new()
 {
     private const string ServerDataErrorMessage = $"ServerData should not be used on {nameof(TyneTableBase<TRequest, TResponse>)}s as this is how Tyne overrides Mud's data loading.";
     /// <summary>

--- a/src/Blazor/Key/KeyEmptyException.cs
+++ b/src/Blazor/Key/KeyEmptyException.cs
@@ -1,5 +1,4 @@
 using System.Runtime.CompilerServices;
-using System.Runtime.Serialization;
 
 namespace Tyne.Blazor;
 
@@ -7,7 +6,6 @@ namespace Tyne.Blazor;
 ///     The exception that is thrown when a <see cref="TyneKey"/> is
 ///     expected to have a value but is <see cref="TyneKey.IsEmpty"/>.
 /// </summary>
-[Serializable]
 public class KeyEmptyException : Exception
 {
     private const string DefaultMessage = "Key cannot be empty here.";
@@ -34,15 +32,6 @@ public class KeyEmptyException : Exception
     /// <param name="message">An error message that explains the reason for the exception.</param>
     /// <param name="innerException">The <see cref="Exception"/> that is the cause of the current exception.</param>
     public KeyEmptyException(string? message, Exception? innerException) : base(message, innerException)
-    {
-    }
-
-    /// <summary>
-    ///     Initializes a new instance of <see cref="KeyEmptyException"/> with serialized data.
-    /// </summary>
-    /// <param name="info">The object that holds the serialized object data.</param>
-    /// <param name="context">The contextual information about the source or destination.</param>
-    protected KeyEmptyException(SerializationInfo info, StreamingContext context) : base(info, context)
     {
     }
 

--- a/src/Core/Core.csproj
+++ b/src/Core/Core.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
     <AssemblyName>Tyne.Core</AssemblyName>
     <RootNamespace>Tyne</RootNamespace>
   </PropertyGroup>

--- a/src/Core/Error/Error.Internal.cs
+++ b/src/Core/Error/Error.Internal.cs
@@ -1,0 +1,54 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Contracts;
+using System.Runtime.CompilerServices;
+
+namespace Tyne.Internal;
+
+/// <summary>
+///     Intended for internal use by Tyne packages working with <see cref="Tyne.Error"/>s.
+/// </summary>
+public static class Error
+{
+    internal const string DefaultCode = "default";
+    internal const string DefaultMessage = "Unknown error.";
+
+    /// <summary>
+    ///     Checks whether <paramref name="code"/> is a valid <see cref="Tyne.Error.Code"/>.
+    /// </summary>
+    /// <param name="code">The error code.</param>
+    /// <returns><see langword="true"/> if the code is a valid error code; otherwise, <see langword="false"/>.</returns>
+    [Pure]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsValidCode([NotNullWhen(true)] string? code) =>
+        !string.IsNullOrWhiteSpace(code);
+
+    /// <summary>
+    ///     Returns <paramref name="code"/> if it is a valid <see cref="Tyne.Error.Code"/>; otherwise, returns a default code.
+    /// </summary>
+    /// <param name="code">The error code.</param>
+    /// <returns>A valid error code.</returns>
+    [Pure]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static string CodeOrDefault(string? code) =>
+        IsValidCode(code) ? code : DefaultCode;
+
+    /// <summary>
+    ///     Checks whether <paramref name="message"/> is a valid <see cref="Tyne.Error.Message"/>.
+    /// </summary>
+    /// <param name="message">The error message.</param>
+    /// <returns><see langword="true"/> if the message is a valid error message; otherwise, <see langword="false"/>.</returns>
+    [Pure]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsValidMessage([NotNullWhen(true)] string? message) =>
+        !string.IsNullOrWhiteSpace(message);
+
+    /// <summary>
+    ///     Returns <paramref name="message"/> if it is a valid <see cref="Tyne.Error.Message"/>; otherwise, returns a default message.
+    /// </summary>
+    /// <param name="message">The error message.</param>
+    /// <returns>A valid error message.</returns>
+    [Pure]
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static string MessageOrDefault(string? message) =>
+        IsValidMessage(message) ? message : DefaultMessage;
+}

--- a/src/Core/Error/ErrorJsonConverter.cs
+++ b/src/Core/Error/ErrorJsonConverter.cs
@@ -13,7 +13,7 @@ public sealed class ErrorJsonConverter : JsonConverter<Error>
     [SuppressMessage("Minor Code Smell", "S3459: Unassigned members should be removed", Justification = "Assignment is done by the json converter.")]
     private sealed class ErrorJsonProxyType
     {
-        public int? Code { get; set; }
+        public string? Code { get; set; }
         public string? Message { get; set; }
     }
 
@@ -41,15 +41,7 @@ public sealed class ErrorJsonConverter : JsonConverter<Error>
         if (errorJsonProxy is null)
             return Error.Default;
 
-        var code = errorJsonProxy.Code ?? Error.DefaultCode;
-        var message = errorJsonProxy.Message;
-
-        if (!Error.IsValidMessage(message))
-            message = Error.DefaultErrorMessage;
-
-        var error = new Error(code, message, null);
-
-        return error;
+        return new Error(errorJsonProxy.Code, errorJsonProxy.Message, null);
     }
 
     public override void Write(Utf8JsonWriter writer, Error value, JsonSerializerOptions options)
@@ -60,7 +52,7 @@ public sealed class ErrorJsonConverter : JsonConverter<Error>
 
         writer.WriteStartObject();
 
-        writer.WriteNumber(nameof(ErrorJsonProxyType.Code), value.Code);
+        writer.WriteString(nameof(ErrorJsonProxyType.Code), value.Code);
         writer.WriteString(nameof(ErrorJsonProxyType.Message), value.Message);
         // CausedBy is intentionally never written
 

--- a/src/Core/Option/BadOptionException.cs
+++ b/src/Core/Option/BadOptionException.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
-using System.Runtime.Serialization;
 
 namespace Tyne;
 
@@ -11,7 +10,6 @@ namespace Tyne;
 ///     This may occur during creation (e.g. passing a null value to <see cref="Option.Some{T}(T)"/>),
 ///     or while accessing an option (e.g. calling <see cref="Option{T}.Value"/> when it is <c>None</c>).
 /// </remarks>
-[Serializable]
 public class BadOptionException : InvalidOperationException
 {
     internal static string DefaultMessage
@@ -53,16 +51,6 @@ public class BadOptionException : InvalidOperationException
     /// <param name="innerException">The <see cref="Exception"/> that is the cause of the current exception.</param>
     public BadOptionException(string message, Exception innerException)
         : base(MessageOrDefault(message), innerException)
-    {
-    }
-
-    /// <summary>
-    ///     Initializes a new instance of <see cref="BadOptionException"/> with serialized data.
-    /// </summary>
-    /// <param name="info">The object that holds the serialized object data.</param>
-    /// <param name="context">The contextual information about the source or destination.</param>
-    protected BadOptionException(SerializationInfo info, StreamingContext context)
-        : base(info, context)
     {
     }
 

--- a/src/Core/Option/UnwrapOptionException.cs
+++ b/src/Core/Option/UnwrapOptionException.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
-using System.Runtime.Serialization;
 
 namespace Tyne;
 
@@ -10,7 +9,6 @@ namespace Tyne;
 /// <remarks>
 ///     See <see cref="OptionExtensions.Unwrap{T}(in Option{T})"/> for how unwrapping works.
 /// </remarks>
-[Serializable]
 public class UnwrapOptionException : BadOptionException
 {
     internal new static string DefaultMessage
@@ -52,16 +50,6 @@ public class UnwrapOptionException : BadOptionException
     /// <param name="innerException">The <see cref="Exception"/> that is the cause of the current exception.</param>
     public UnwrapOptionException(string message, Exception innerException)
         : base(MessageOrDefault(message), innerException)
-    {
-    }
-
-    /// <summary>
-    ///     Initializes a new instance of <see cref="UnwrapOptionException"/> with serialized data.
-    /// </summary>
-    /// <param name="info">The object that holds the serialized object data.</param>
-    /// <param name="context">The contextual information about the source or destination.</param>
-    protected UnwrapOptionException(SerializationInfo info, StreamingContext context)
-        : base(info, context)
     {
     }
 

--- a/src/Core/Preludes/ErrorPrelude.cs
+++ b/src/Core/Preludes/ErrorPrelude.cs
@@ -17,15 +17,15 @@ public static class ErrorPrelude
     public static Error Error(string message) =>
         Tyne.Error.From(message);
 
-    /// <inheritdoc cref="Error.From(int, string)"/>
+    /// <inheritdoc cref="Error.From(string, string)"/>
     [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Error Error(int code, string message) =>
+    public static Error Error(string code, string message) =>
         Tyne.Error.From(code, message);
 
-    /// <inheritdoc cref="Error.From(int, string, Exception?)"/>
+    /// <inheritdoc cref="Error.From(string, string, Exception?)"/>
     [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Error Error(int code, string message, Exception? causedBy) =>
+    public static Error Error(string code, string message, Exception? causedBy) =>
         Tyne.Error.From(code, message, causedBy);
 }

--- a/src/Core/Preludes/ResultPrelude.cs
+++ b/src/Core/Preludes/ResultPrelude.cs
@@ -23,16 +23,16 @@ public static class ResultPrelude
     public static Result<T> Error<T>(string message) =>
         Result.Error<T>(message);
 
-    /// <inheritdoc cref="Result.Error{T}(int, string)"/>
+    /// <inheritdoc cref="Result.Error{T}(string, string)"/>
     [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<T> Error<T>(int code, string message) =>
+    public static Result<T> Error<T>(string code, string message) =>
         Result.Error<T>(code, message);
 
-    /// <inheritdoc cref="Result.Error{T}(int, string, Exception)"/>
+    /// <inheritdoc cref="Result.Error{T}(string, string, Exception)"/>
     [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<T> Error<T>(int code, string message, Exception causedBy) =>
+    public static Result<T> Error<T>(string code, string message, Exception causedBy) =>
         Result.Error<T>(code, message, causedBy);
 
     /// <inheritdoc cref="Result.Error{T}(in Error)"/>

--- a/src/Core/Result/BadResultException.cs
+++ b/src/Core/Result/BadResultException.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
-using System.Runtime.Serialization;
 
 namespace Tyne;
 
@@ -11,7 +10,6 @@ namespace Tyne;
 ///     This may occur during result creation (e.g. passing a null value to <see cref="Result.Ok{T}(in T)"/>),
 ///     or while accessing a result (e.g. calling <see cref="Result{T}.Value"/> when it is an error).
 /// </remarks>
-[Serializable]
 public class BadResultException : InvalidOperationException
 {
     internal static string DefaultMessage
@@ -53,16 +51,6 @@ public class BadResultException : InvalidOperationException
     /// <param name="innerException">The <see cref="Exception"/> that is the cause of the current exception.</param>
     public BadResultException(string message, Exception innerException)
         : base(MessageOrDefault(message), innerException)
-    {
-    }
-
-    /// <summary>
-    ///     Initializes a new instance of <see cref="BadResultException"/> with serialized data.
-    /// </summary>
-    /// <param name="info">The object that holds the serialized object data.</param>
-    /// <param name="context">The contextual information about the source or destination.</param>
-    protected BadResultException(SerializationInfo info, StreamingContext context)
-        : base(info, context)
     {
     }
 

--- a/src/Core/Result/Result.cs
+++ b/src/Core/Result/Result.cs
@@ -76,7 +76,7 @@ public static class Result
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Result<T> Error<T>(string message)
     {
-        // Let Error handle a potentially null message
+        // Let Error handle invalid codes/messages
         var error = new Error(Tyne.Error.DefaultCode, message, null);
         return new Result<T>(error);
     }
@@ -90,9 +90,9 @@ public static class Result
     /// <returns>An <c>Error</c> <see cref="Result{T}"/> whose error is constructed using <paramref name="code"/> and <paramref name="message"/>.</returns>
     [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<T> Error<T>(int code, string message)
+    public static Result<T> Error<T>(string code, string message)
     {
-        // Let Error handle a potentially null message
+        // Let Error handle invalid codes/messages
         var error = new Error(code, message, null);
         return new Result<T>(error);
     }
@@ -107,9 +107,9 @@ public static class Result
     /// <returns>An <c>Error</c> <see cref="Result{T}"/> whose error is constructed using <paramref name="code"/>, <paramref name="message"/>, and <paramref name="causedBy"/>.</returns>
     [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Result<T> Error<T>(int code, string message, Exception causedBy)
+    public static Result<T> Error<T>(string code, string message, Exception causedBy)
     {
-        // Let Error handle potential nulls
+        // Let Error handle invalid codes/messages
         var error = new Error(code, message, causedBy);
         return new Result<T>(error);
     }

--- a/src/Core/Result/Result`1.cs
+++ b/src/Core/Result/Result`1.cs
@@ -265,7 +265,7 @@ public class Result<T> : IEquatable<Result<T>>
     public override string ToString()
     {
         if (!_isOk)
-            return _error!.ToString();
+            return _error!.ToString(includeCode: true);
 
         var valueString = _value!.ToString();
         // 4 accounts for "Ok(" + ")"

--- a/src/Core/Result/UnwrapResultErrorException.cs
+++ b/src/Core/Result/UnwrapResultErrorException.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
-using System.Runtime.Serialization;
 
 namespace Tyne;
 
@@ -10,7 +9,6 @@ namespace Tyne;
 /// <remarks>
 ///     See <see cref="ResultExtensions.UnwrapError{T}(Result{T})"/> for how unwrapping works.
 /// </remarks>
-[Serializable]
 public class UnwrapResultErrorException : BadResultException
 {
     internal new static string DefaultMessage
@@ -53,16 +51,6 @@ public class UnwrapResultErrorException : BadResultException
     /// <param name="innerException">The <see cref="Exception"/> that is the cause of the current exception.</param>
     public UnwrapResultErrorException(string message, Exception innerException)
         : base(MessageOrDefault(message), innerException)
-    {
-    }
-
-    /// <summary>
-    ///     Initializes a new instance of <see cref="UnwrapResultErrorException"/> with serialized data.
-    /// </summary>
-    /// <param name="info">The object that holds the serialized object data.</param>
-    /// <param name="context">The contextual information about the source or destination.</param>
-    protected UnwrapResultErrorException(SerializationInfo info, StreamingContext context)
-        : base(info, context)
     {
     }
 

--- a/src/Core/Result/UnwrapResultValueException.cs
+++ b/src/Core/Result/UnwrapResultValueException.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics.Contracts;
 using System.Runtime.CompilerServices;
-using System.Runtime.Serialization;
 
 namespace Tyne;
 
@@ -10,7 +9,6 @@ namespace Tyne;
 /// <remarks>
 ///     See <see cref="ResultExtensions.Unwrap{T}(Result{T})"/> for how unwrapping works.
 /// </remarks>
-[Serializable]
 public class UnwrapResultValueException : BadResultException
 {
     internal new static string DefaultMessage
@@ -53,16 +51,6 @@ public class UnwrapResultValueException : BadResultException
     /// <param name="innerException">The <see cref="Exception"/> that is the cause of the current exception.</param>
     public UnwrapResultValueException(string message, Exception innerException)
         : base(MessageOrDefault(message), innerException)
-    {
-    }
-
-    /// <summary>
-    ///     Initializes a new instance of <see cref="UnwrapResultValueException"/> with serialized data.
-    /// </summary>
-    /// <param name="info">The object that holds the serialized object data.</param>
-    /// <param name="context">The contextual information about the source or destination.</param>
-    protected UnwrapResultValueException(SerializationInfo info, StreamingContext context)
-        : base(info, context)
     {
     }
 

--- a/src/Core/Searching/SearchResultsConverterFactory.cs
+++ b/src/Core/Searching/SearchResultsConverterFactory.cs
@@ -64,7 +64,7 @@ public sealed class SearchResultsConverterFactory : JsonConverterFactory
     private sealed class SearchResultsJsonProxyType<T>
     {
         public int TotalCount { get; set; }
-        public List<T> Values { get; set; } = new();
+        public List<T> Values { get; set; } = [];
     }
 
     [SuppressMessage("Performance", "CA1812: Avoid uninstantiated internal classes", Justification = "Class is instantiated by Activator.CreateInstance.")]
@@ -93,7 +93,7 @@ public sealed class SearchResultsConverterFactory : JsonConverterFactory
             var searchResultsJsonProxy = new SearchResultsJsonProxyType<T>
             {
                 TotalCount = value.TotalCount,
-                Values = value.ToList()
+                Values = [..value]
             };
             _proxyTypeConverter.Write(writer, searchResultsJsonProxy, options);
         }

--- a/src/EntityFramework.ChangeAuditing/Auditor/DbContextChangeAuditor`3.cs
+++ b/src/EntityFramework.ChangeAuditing/Auditor/DbContextChangeAuditor`3.cs
@@ -103,7 +103,7 @@ public class DbContextChangeAuditor<TEvent, TProperty, TRelation> : IDbContextCh
                             };
                         })
                         .ToList(),
-                    Parents = new()
+                    Parents = []
                 },
                 ParentInfos =
                     entry.Navigations

--- a/src/EntityFramework.ChangeAuditing/EntityFramework.ChangeAuditing.csproj
+++ b/src/EntityFramework.ChangeAuditing/EntityFramework.ChangeAuditing.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
     <AssemblyName>Tyne.EntityFramework.ChangeAuditing</AssemblyName>
     <RootNamespace>Tyne.EntityFramework</RootNamespace>
   </PropertyGroup>

--- a/src/EntityFramework.ModificationTracking/EntityFramework.ModificationTracking.csproj
+++ b/src/EntityFramework.ModificationTracking/EntityFramework.ModificationTracking.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
     <AssemblyName>Tyne.EntityFramework.ModificationTracking</AssemblyName>
     <RootNamespace>Tyne.EntityFramework</RootNamespace>
   </PropertyGroup>

--- a/src/EntityFramework.UserService.Core/EntityFramework.UserService.Core.csproj
+++ b/src/EntityFramework.UserService.Core/EntityFramework.UserService.Core.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
     <AssemblyName>Tyne.EntityFramework.UserService.Core</AssemblyName>
     <RootNamespace>Tyne</RootNamespace>
   </PropertyGroup>

--- a/src/EntityFramework.UserService/EntityFramework.UserService.csproj
+++ b/src/EntityFramework.UserService/EntityFramework.UserService.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
     <AssemblyName>Tyne.EntityFramework.UserService</AssemblyName>
     <RootNamespace>Tyne</RootNamespace>
   </PropertyGroup>

--- a/src/EntityFramework/EntityFramework.csproj
+++ b/src/EntityFramework/EntityFramework.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
     <AssemblyName>Tyne.EntityFramework</AssemblyName>
     <RootNamespace>Tyne.EntityFramework</RootNamespace>
   </PropertyGroup>

--- a/src/HttpMediator.Client/ErrorsCodes.cs
+++ b/src/HttpMediator.Client/ErrorsCodes.cs
@@ -1,0 +1,12 @@
+namespace Tyne.HttpMediator.Client;
+
+/// <summary>
+///     Errors codes for <see cref="Error"/>s created as part of <c>Tyne.HttpMediator.Client</c>.
+/// </summary>
+public static class ErrorsCodes
+{
+    /// <summary>
+    ///     The error code used when an unhandled exception is caught in the middleware pipeline.
+    /// </summary>
+    public static readonly string UnhandledExceptionMiddleware = "Tyne.HttpMediator.Client.UnhandledException";
+}

--- a/src/HttpMediator.Client/Middleware/Implementations/ExceptionHandler/ExceptionHandlerMiddleware.cs
+++ b/src/HttpMediator.Client/Middleware/Implementations/ExceptionHandler/ExceptionHandlerMiddleware.cs
@@ -25,7 +25,7 @@ internal sealed class ExceptionHandlerMiddleware : IHttpMediatorMiddleware
         catch (Exception exception)
         {
             _logger.LogUnhandledHttpMediatorPipelineException(exception);
-            var error = Error.From(Error.DefaultCode, "An unknown error occurred.", exception);
+            var error = Error.From(ErrorsCodes.UnhandledExceptionMiddleware, Error.Default.Message, exception);
             // We don't know what happened, fall back to it being a bad request
             return HttpResult.Codes.BadRequest<TResponse>(error);
         }

--- a/src/HttpMediator.Client/Middleware/Implementations/HttpSender/HttpSenderRequestMessageFactory.cs
+++ b/src/HttpMediator.Client/Middleware/Implementations/HttpSender/HttpSenderRequestMessageFactory.cs
@@ -95,7 +95,7 @@ internal sealed class HttpSenderRequestMessageFactory
         object? requestDataObj;
         try
         {
-            requestDataObj = genericMethodInfo.Invoke(this, Array.Empty<object?>());
+            requestDataObj = genericMethodInfo.Invoke(this, []);
         }
         catch (TargetInvocationException invocationException)
         {

--- a/src/HttpMediator.Client/Registration/HttpMediatorMiddlewareBuilder.cs
+++ b/src/HttpMediator.Client/Registration/HttpMediatorMiddlewareBuilder.cs
@@ -16,7 +16,7 @@ public sealed class HttpMediatorMiddlewareBuilder
 
     internal HttpMediatorMiddlewareBuilder(IServiceCollection services)
     {
-        Middleware = new();
+        Middleware = [];
         Services = services;
     }
 

--- a/src/HttpMediator.Client/ResultReader/HttpResponseResultReaderLogging.cs
+++ b/src/HttpMediator.Client/ResultReader/HttpResponseResultReaderLogging.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using Tyne.Internal.HttpMediator;
 
 namespace Tyne.HttpMediator.Client;
 

--- a/src/HttpMediator.Core/HttpMediator.Core.csproj
+++ b/src/HttpMediator.Core/HttpMediator.Core.csproj
@@ -15,7 +15,6 @@
   </ItemGroup>
   
   <ItemGroup>
-    <InternalsVisibleTo Include="Tyne.HttpMediator.Client" />
     <InternalsVisibleTo Include="Tyne.HttpMediator.Client.UnitTests" />
     <InternalsVisibleTo Include="Tyne.HttpMediator.Server" />
   </ItemGroup>

--- a/src/HttpMediator.Core/HttpMediatorOptionsBase.cs
+++ b/src/HttpMediator.Core/HttpMediatorOptionsBase.cs
@@ -61,10 +61,10 @@ public abstract class HttpMediatorOptionsBase
             return "/";
         }
 
-        if (!apiBase.StartsWith("/", StringComparison.Ordinal))
+        if (!apiBase.StartsWith('/'))
             apiBase = "/" + apiBase;
 
-        if (!apiBase.EndsWith("/", StringComparison.Ordinal))
+        if (!apiBase.EndsWith('/'))
             apiBase += "/";
 
         return apiBase;

--- a/src/HttpMediator.Core/HttpResults/Codes/HttpResultCodesExtensions.BadRequest.cs
+++ b/src/HttpMediator.Core/HttpResults/Codes/HttpResultCodesExtensions.BadRequest.cs
@@ -32,7 +32,7 @@ public static partial class HttpResultCodesExtensions
     /// <returns>An <c>Error</c> <see cref="HttpResult{T}"/> whose error is constructed using <paramref name="code"/> and <paramref name="message"/>.</returns>
     [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static HttpResult<T> BadRequest<T>(this HttpResultCodes _, int code, string message) =>
+    public static HttpResult<T> BadRequest<T>(this HttpResultCodes _, string code, string message) =>
         HttpResult.Error<T>(code, message, HttpStatusCode.BadRequest);
 
     /// <summary>

--- a/src/HttpMediator.Core/HttpResults/Codes/HttpResultCodesExtensions.Forbidden.cs
+++ b/src/HttpMediator.Core/HttpResults/Codes/HttpResultCodesExtensions.Forbidden.cs
@@ -22,10 +22,10 @@ public static partial class HttpResultCodesExtensions
     ///     (i.e. <see cref="Result{T}.IsOk"/> is <see langword="false"/>)
     ///     with <see cref="HttpStatusCode.Forbidden"/>.
     /// </summary>
-    /// <inheritdoc cref="BadRequest{T}(HttpResultCodes, int, string)"/>
+    /// <inheritdoc cref="BadRequest{T}(HttpResultCodes, string, string)"/>
     [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static HttpResult<T> Forbidden<T>(this HttpResultCodes _, int code, string message) =>
+    public static HttpResult<T> Forbidden<T>(this HttpResultCodes _, string code, string message) =>
         HttpResult.Error<T>(code, message, HttpStatusCode.Forbidden);
 
     /// <summary>

--- a/src/HttpMediator.Core/HttpResults/Codes/HttpResultCodesExtensions.InternalServerError.cs
+++ b/src/HttpMediator.Core/HttpResults/Codes/HttpResultCodesExtensions.InternalServerError.cs
@@ -22,10 +22,10 @@ public static partial class HttpResultCodesExtensions
     ///     (i.e. <see cref="Result{T}.IsOk"/> is <see langword="false"/>)
     ///     with <see cref="HttpStatusCode.InternalServerError"/>.
     /// </summary>
-    /// <inheritdoc cref="BadRequest{T}(HttpResultCodes, int, string)"/>
+    /// <inheritdoc cref="BadRequest{T}(HttpResultCodes, string, string)"/>
     [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static HttpResult<T> InternalServerError<T>(this HttpResultCodes _, int code, string message) =>
+    public static HttpResult<T> InternalServerError<T>(this HttpResultCodes _, string code, string message) =>
         HttpResult.Error<T>(code, message, HttpStatusCode.InternalServerError);
 
     /// <summary>

--- a/src/HttpMediator.Core/HttpResults/Codes/HttpResultCodesExtensions.NotFound.cs
+++ b/src/HttpMediator.Core/HttpResults/Codes/HttpResultCodesExtensions.NotFound.cs
@@ -22,10 +22,10 @@ public static partial class HttpResultCodesExtensions
     ///     (i.e. <see cref="Result{T}.IsOk"/> is <see langword="false"/>)
     ///     with <see cref="HttpStatusCode.NotFound"/>.
     /// </summary>
-    /// <inheritdoc cref="BadRequest{T}(HttpResultCodes, int, string)"/>
+    /// <inheritdoc cref="BadRequest{T}(HttpResultCodes, string, string)"/>
     [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static HttpResult<T> NotFound<T>(this HttpResultCodes _, int code, string message) =>
+    public static HttpResult<T> NotFound<T>(this HttpResultCodes _, string code, string message) =>
         HttpResult.Error<T>(code, message, HttpStatusCode.NotFound);
 
     /// <summary>

--- a/src/HttpMediator.Core/HttpResults/Codes/HttpResultCodesExtensions.Unauthorized.cs
+++ b/src/HttpMediator.Core/HttpResults/Codes/HttpResultCodesExtensions.Unauthorized.cs
@@ -22,10 +22,10 @@ public static partial class HttpResultCodesExtensions
     ///     (i.e. <see cref="Result{T}.IsOk"/> is <see langword="false"/>)
     ///     with <see cref="HttpStatusCode.Unauthorized"/>.
     /// </summary>
-    /// <inheritdoc cref="BadRequest{T}(HttpResultCodes, int, string)"/>
+    /// <inheritdoc cref="BadRequest{T}(HttpResultCodes, string, string)"/>
     [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static HttpResult<T> Unauthorized<T>(this HttpResultCodes _, int code, string message) =>
+    public static HttpResult<T> Unauthorized<T>(this HttpResultCodes _, string code, string message) =>
         HttpResult.Error<T>(code, message, HttpStatusCode.Unauthorized);
 
     /// <summary>

--- a/src/HttpMediator.Core/HttpResults/HttpResult.cs
+++ b/src/HttpMediator.Core/HttpResults/HttpResult.cs
@@ -62,7 +62,7 @@ public static class HttpResult
     public static HttpResult<T> Error<T>(string message, HttpStatusCode statusCode)
     {
         // Let Error handle a potentially null message
-        var error = Tyne.Error.From(Tyne.Error.DefaultCode, message);
+        var error = Tyne.Error.From(message);
         // HttpResult's constructor handles invalid status codes
         return new(error, statusCode);
     }
@@ -85,9 +85,9 @@ public static class HttpResult
     /// </exception>
     [Pure]
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static HttpResult<T> Error<T>(int code, string message, HttpStatusCode statusCode)
+    public static HttpResult<T> Error<T>(string code, string message, HttpStatusCode statusCode)
     {
-        // Let Error handle a potentially null message
+        // Let Error handle a potentially null code/message
         var error = Tyne.Error.From(code, message);
         // HttpResult's constructor handles invalid status codes
         return new(error, statusCode);

--- a/src/HttpMediator.Core/ProblemDetails.cs
+++ b/src/HttpMediator.Core/ProblemDetails.cs
@@ -14,14 +14,15 @@
 
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 
-namespace Tyne.HttpMediator;
+namespace Tyne.Internal.HttpMediator;
 
 /// <summary>
 ///     A machine-readable format for specifying errors in HTTP API responses based on <see href="https://tools.ietf.org/html/rfc7807"/>.
 /// </summary>
-internal sealed class ProblemDetails
+public sealed class ProblemDetails
 {
     /// <summary>
     ///     A URI reference [RFC3986] that identifies the problem type.
@@ -81,5 +82,6 @@ internal sealed class ProblemDetails
     ///     In particular, complex types or collection types may not round-trip to the original type when using the built-in JSON or XML formatters.
     /// </remarks>
     [JsonExtensionData]
+    [SuppressMessage("Usage", "CA2227: Collection properties should be read only.", Justification = "This should be mutable for JSON de/serialisation.")]
     public IDictionary<string, object?> Extensions { get; set; } = new Dictionary<string, object?>(StringComparer.Ordinal);
 }

--- a/src/HttpMediator.Server/ErrorsCodes.cs
+++ b/src/HttpMediator.Server/ErrorsCodes.cs
@@ -1,0 +1,12 @@
+namespace Tyne.HttpMediator.Server;
+
+/// <summary>
+///     Errors codes for <see cref="Error"/>s created as part of <c>Tyne.HttpMediator.Server</c>.
+/// </summary>
+public static class ErrorsCodes
+{
+    /// <summary>
+    ///     The error code used when an unhandled exception is caught in the middleware pipeline.
+    /// </summary>
+    public static readonly string UnhandledExceptionMiddleware = "Tyne.HttpMediator.Server.UnhandledException";
+}

--- a/src/HttpMediator.Server/Middleware/Implementations/ExceptionHandler/ExceptionHandlerMiddleware.cs
+++ b/src/HttpMediator.Server/Middleware/Implementations/ExceptionHandler/ExceptionHandlerMiddleware.cs
@@ -27,8 +27,9 @@ internal sealed class ExceptionHandlerMiddleware : IHttpMediatorMiddleware
         catch (Exception exception)
         {
             _logger.LogUnhandledHttpMediatorPipelineException(exception);
+            var error = Error.From(ErrorsCodes.UnhandledExceptionMiddleware, Error.Default.Message, exception);
             // We don't know what happened, fall back to it being a server error
-            return HttpResult.Codes.InternalServerError<TResponse>("An unknown error occurred.");
+            return HttpResult.Codes.InternalServerError<TResponse>(error);
         }
     }
 }

--- a/src/HttpMediator.Server/Registration/HttpMediatorMiddlewareBuilder.cs
+++ b/src/HttpMediator.Server/Registration/HttpMediatorMiddlewareBuilder.cs
@@ -16,7 +16,7 @@ public sealed class HttpMediatorMiddlewareBuilder
 
     internal HttpMediatorMiddlewareBuilder(IServiceCollection services)
     {
-        Middleware = new();
+        Middleware = [];
         Services = services;
     }
 

--- a/src/HttpMediator.Server/ResultWriter/HttpResponseResultWriter.cs
+++ b/src/HttpMediator.Server/ResultWriter/HttpResponseResultWriter.cs
@@ -2,6 +2,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
+using Tyne.Internal.HttpMediator;
 
 namespace Tyne.HttpMediator.Server;
 

--- a/src/HttpMediator.Server/ResultWriter/IHttpResponseResultWriter.cs
+++ b/src/HttpMediator.Server/ResultWriter/IHttpResponseResultWriter.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Http;
+using Tyne.Internal.HttpMediator;
 
 namespace Tyne.HttpMediator.Server;
 
@@ -11,7 +12,7 @@ namespace Tyne.HttpMediator.Server;
 ///     <para>
 ///         While this can be achieved through <see cref="JsonConverter{T}"/>,
 ///         this way writes <c>Ok(T)</c> results directly,
-///         and transforms <c>Error</c> results into <see cref="ProblemDetails"/>.
+///         and transforms <c>Error</c> results into <see href="https://datatracker.ietf.org/doc/html/rfc7807"/> (<see cref="ProblemDetails"/>).
 ///         It also handles setting the <see cref="HttpResponse.StatusCode"/>.
 ///     </para>
 ///     <para>

--- a/src/Testing/Testing.csproj
+++ b/src/Testing/Testing.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
     <AssemblyName>Tyne.Testing</AssemblyName>
     <RootNamespace>Tyne</RootNamespace>
   </PropertyGroup>

--- a/test/AspNetCore.IntegrationTests.TestWebApp/AspNetCore.IntegrationTests.TestWebApp.csproj
+++ b/test/AspNetCore.IntegrationTests.TestWebApp/AspNetCore.IntegrationTests.TestWebApp.csproj
@@ -16,4 +16,6 @@
     <PackageReference Include="MediatR" />
   </ItemGroup>
 
+  <Import Project="../../eng/Tests.props" />
+
 </Project>

--- a/test/AspNetCore.IntegrationTests.TestWebApp/AspNetCore.IntegrationTests.TestWebApp.csproj
+++ b/test/AspNetCore.IntegrationTests.TestWebApp/AspNetCore.IntegrationTests.TestWebApp.csproj
@@ -2,8 +2,11 @@
 
   <PropertyGroup>
     <AssemblyName>Tyne.AspNetCore.IntegrationTests.TestApp</AssemblyName>
-    <RootNamespace>Tyne.AspNetCore.TestApp</RootNamespace>
+    <RootNamespace>Tyne.AspNetCore</RootNamespace>
     <IsTestProject>false</IsTestProject>
+    <!-- Prevents dotnet pack from trying to pack this, and then warning when it can't -->
+    <IsPackable>false</IsPackable>
+    <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/AspNetCore.IntegrationTests.TestWebApp/TestWebAppHost.cs
+++ b/test/AspNetCore.IntegrationTests.TestWebApp/TestWebAppHost.cs
@@ -1,19 +1,36 @@
 using System.Diagnostics.CodeAnalysis;
 
-namespace Tyne.AspNetCore.TestApp;
+namespace Tyne.AspNetCore;
 
 [SuppressMessage("Major Code Smell", "S1118:Utility classes should not have public constructors", Justification = "It's not a utility class.")]
 public sealed class TestWebAppHost
 {
+    public const string NotFoundSyncHandlerHeaderKey = "NotFoundSyncHeader";
+    public const string NotFoundAsyncHandlerBodyMessage = "Not found async handler content";
+
+    public const int InvalidTestRequestStatusCode = 418;
+    public const string InvalidTestRequestBodyMessage = "invalid test request";
+
     public static void Main(string[] args)
     {
         var builder = WebApplication.CreateBuilder(args);
 
-        builder.Services.AddProblemDetails();
+        builder.Services.AddControllersWithViews();
+        builder.Services.AddRazorPages();
 
         using var app = builder.Build();
 
         app.UseRouting();
+
+        app.MapFallbackToNotFound("/test/notfound/default/{**_}");
+        app.MapFallbackToNotFound("/test/notfound/sync-handler/{**_}", httpContext => httpContext.Response.Headers.Append(NotFoundSyncHandlerHeaderKey, "true"));
+        app.MapFallbackToNotFound("/test/notfound/async-handler/{**_}", async httpContext => await httpContext.Response.WriteAsync(NotFoundAsyncHandlerBodyMessage));
+
+        app.MapFallback("{**_}", async httpContext =>
+        {
+            httpContext.Response.StatusCode = InvalidTestRequestStatusCode;
+            await httpContext.Response.WriteAsync(InvalidTestRequestBodyMessage);
+        });
 
         app.Run();
     }

--- a/test/AspNetCore.IntegrationTests/AspNetCore.IntegrationTests.csproj
+++ b/test/AspNetCore.IntegrationTests/AspNetCore.IntegrationTests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <AssemblyName>Tyne.AspNetCore.IntegrationTests</AssemblyName>
     <RootNamespace>Tyne.AspNetCore</RootNamespace>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,13 +13,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.16" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="NSubstitute" />
-    <PackageReference Include="NSubstitute.Analyzers.CSharp" PrivateAssets="all" />
-    <PackageReference Include="xunit" />
-    <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" />
   </ItemGroup>
+
+  <Import Project="../../eng/Tests.props" />
 
 </Project>

--- a/test/AspNetCore.IntegrationTests/AspNetCore.IntegrationTests.csproj
+++ b/test/AspNetCore.IntegrationTests/AspNetCore.IntegrationTests.csproj
@@ -4,6 +4,9 @@
     <AssemblyName>Tyne.AspNetCore.IntegrationTests</AssemblyName>
     <RootNamespace>Tyne.AspNetCore</RootNamespace>
     <IsTestProject>true</IsTestProject>
+    <!-- Prevents dotnet pack from trying to pack this, and then warning when it can't -->
+    <IsPackable>false</IsPackable>
+    <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/AspNetCore.IntegrationTests/Endpoints/NotFoundEndpointTests.cs
+++ b/test/AspNetCore.IntegrationTests/Endpoints/NotFoundEndpointTests.cs
@@ -1,0 +1,136 @@
+using System.Diagnostics;
+using System;
+using System.Net;
+
+namespace Tyne.AspNetCore.Endpoints;
+
+[Collection(TestWebAppCollection.Name)]
+public class NotFoundEndpointTests
+{
+    private TestWebAppFactory TestWebApp { get; }
+
+    public NotFoundEndpointTests(TestWebAppFactory testWebAppFactory)
+    {
+        TestWebApp = testWebAppFactory;
+    }
+
+    public static TheoryData<HttpMethod> SupportedMethodsData => new(SupportedMethods);
+    public static IEnumerable<HttpMethod> SupportedMethods
+    {
+        get
+        {
+            yield return HttpMethod.Put;
+            yield return HttpMethod.Post;
+            yield return HttpMethod.Patch;
+            yield return HttpMethod.Options;
+            yield return HttpMethod.Head;
+            yield return HttpMethod.Get;
+            yield return HttpMethod.Delete;
+        }
+    }
+
+    public static TheoryData<HttpMethod, Uri> GetUris(string type)
+    {
+        var theoryData = new TheoryData<HttpMethod, Uri>();
+        foreach (var uri in EnumerateUris())
+        {
+            foreach (var method in SupportedMethods)
+            {
+                theoryData.Add(method, new Uri(uri, UriKind.Relative));
+            }
+        }
+        return theoryData;
+
+        IEnumerable<string> EnumerateUris()
+        {
+            yield return $"/test/notfound/{type}";
+            yield return $"/test/notfound/{type}/";
+            yield return $"/test/notfound/{type}/test";
+            yield return $"/test/notfound/{type}/test/with/path";
+            yield return $"/test/notfound/{type}/test?with=query&and=a#fragment";
+        }
+    }
+
+    public static TheoryData<HttpMethod, Uri> GetDefaultUris() =>
+        GetUris("default");
+
+    public static TheoryData<HttpMethod, Uri> GetSyncHandlerUris() =>
+        GetUris("sync-handler");
+
+    public static TheoryData<HttpMethod, Uri> GetAsyncHandlerUris() =>
+        GetUris("async-handler");
+
+    [Theory]
+    [MemberData(nameof(GetDefaultUris))]
+    public async Task NoHandler_ReturnsEmpty404(HttpMethod method, Uri uri)
+    {
+        // Arrange
+        var httpClient = TestWebApp.CreateClient();
+
+        // Act
+        using var request = CreateRequest(method, uri);
+        var response = await httpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        var responseContent = await response.Content.ReadAsByteArrayAsync();
+        Assert.Empty(responseContent);
+    }
+
+    [Theory]
+    [MemberData(nameof(GetSyncHandlerUris))]
+    public async Task SyncHandler_ReturnsEmpty404WithHeader(HttpMethod method, Uri uri)
+    {
+        // Arrange
+        var httpClient = TestWebApp.CreateClient();
+
+        // Act
+        using var request = CreateRequest(method, uri);
+        var response = await httpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        var responseContent = await response.Content.ReadAsByteArrayAsync();
+        Assert.Empty(responseContent);
+        Assert.Contains(response.Headers, header => header.Key == TestWebAppHost.NotFoundSyncHandlerHeaderKey);
+    }
+
+    [Theory]
+    [MemberData(nameof(GetAsyncHandlerUris))]
+    public async Task AsyncHandler_Returns404WithCustomContent(HttpMethod method, Uri uri)
+    {
+        // Arrange
+        var httpClient = TestWebApp.CreateClient();
+
+        // Act
+        using var request = CreateRequest(method, uri);
+        var response = await httpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        var responseContent = await response.Content.ReadAsStringAsync();
+        Assert.Equal(TestWebAppHost.NotFoundAsyncHandlerBodyMessage, responseContent);
+    }
+
+    // This tests that the web app host returns a BadRequest
+    // for invalid 'not found' endpoints rather than
+    // using the default ASP.NET fallback behaviour
+    [Theory]
+    [MemberData(nameof(SupportedMethodsData))]
+    public async Task Unhandled_ReturnsBadRequest(HttpMethod method)
+    {
+        // Arrange
+        var httpClient = TestWebApp.CreateClient();
+
+        // Act
+        using var request = CreateRequest(method, new Uri("/_meta/unmapped/path", UriKind.Relative));
+        var response = await httpClient.SendAsync(request);
+
+        Assert.Equal(TestWebAppHost.InvalidTestRequestStatusCode, (int)response.StatusCode);
+        var responseContent = await response.Content.ReadAsStringAsync();
+        Assert.Equal(TestWebAppHost.InvalidTestRequestBodyMessage, responseContent);
+    }
+
+    private static HttpRequestMessage CreateRequest(HttpMethod method, Uri uri) =>
+        new HttpRequestMessage(method, uri);
+}

--- a/test/AspNetCore.IntegrationTests/TestWebAppCollection.cs
+++ b/test/AspNetCore.IntegrationTests/TestWebAppCollection.cs
@@ -1,0 +1,10 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Tyne.AspNetCore;
+
+[CollectionDefinition(Name)]
+[SuppressMessage("Naming", "CA1711:Identifiers should not have incorrect suffix", Justification = "This is an xUnit convention.")]
+public class TestWebAppCollection : ICollectionFixture<TestWebAppFactory>
+{
+    public const string Name = nameof(TestWebAppCollection);
+}

--- a/test/AspNetCore.IntegrationTests/TestWebAppFactory.cs
+++ b/test/AspNetCore.IntegrationTests/TestWebAppFactory.cs
@@ -1,0 +1,17 @@
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+
+namespace Tyne.AspNetCore;
+
+public class TestWebAppFactory : WebApplicationFactory<TestWebAppHost>
+{
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        base.ConfigureWebHost(builder);
+
+        builder.ConfigureTestServices(services =>
+        {
+            services.AddScoped(_ => CreateClient());
+        });
+    }
+}

--- a/test/Blazor.Tests/Blazor.Tests.csproj
+++ b/test/Blazor.Tests/Blazor.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
     <AssemblyName>Tyne.Blazor.Tests</AssemblyName>
     <RootNamespace>Tyne.Blazor</RootNamespace>
   </PropertyGroup>

--- a/test/Blazor.Tests/Blazor.Tests.csproj
+++ b/test/Blazor.Tests/Blazor.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <AssemblyName>Tyne.Blazor.Tests</AssemblyName>
     <RootNamespace>Tyne.Blazor</RootNamespace>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,12 +13,6 @@
 
   <ItemGroup>
     <PackageReference Include="bunit" />
-    <PackageReference Include="coverlet.collector" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="NSubstitute" />
-    <PackageReference Include="NSubstitute.Analyzers.CSharp" PrivateAssets="all" />
-    <PackageReference Include="xunit" />
-    <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" />
   </ItemGroup>
 
   <Import Project="../../eng/Tests.props" />

--- a/test/Blazor.Tests/Persistence/UrlPersistenceService_BulkSetValuesTests.cs
+++ b/test/Blazor.Tests/Persistence/UrlPersistenceService_BulkSetValuesTests.cs
@@ -7,10 +7,10 @@ namespace Tyne.Blazor.Persistence;
 
 public class UrlPersistenceService_BulkSetValuesTests : TestContext
 {
-    public UrlPersistenceService_BulkSetValuesTests() : base()
+    public UrlPersistenceService_BulkSetValuesTests()
     {
         Services.AddSingleton<IUrlQueryStringFormatter, UrlQueryStringFormatter>();
-        Services.AddSingleton<UrlPersistenceService>();
+        Services.AddScoped<UrlPersistenceService>();
     }
 
     [Fact]

--- a/test/Blazor.Tests/Persistence/UrlPersistenceService_GetValueTests.cs
+++ b/test/Blazor.Tests/Persistence/UrlPersistenceService_GetValueTests.cs
@@ -23,10 +23,10 @@ public class UrlPersistenceService_GetValueTests : TestContext
         return method;
     }
 
-    public UrlPersistenceService_GetValueTests() : base()
+    public UrlPersistenceService_GetValueTests()
     {
         Services.AddSingleton<IUrlQueryStringFormatter, UrlQueryStringFormatter>();
-        Services.AddSingleton<UrlPersistenceService>();
+        Services.AddScoped<UrlPersistenceService>();
     }
 
     public static IEnumerable<object?[]> GetValue_Data => UrlUtilities_TestHelpers.StringToValue_Data;

--- a/test/Blazor.Tests/Persistence/UrlPersistenceService_SetValueTests.cs
+++ b/test/Blazor.Tests/Persistence/UrlPersistenceService_SetValueTests.cs
@@ -9,10 +9,10 @@ public class UrlPersistenceService_SetValueTests : TestContext
 {
     private const string QueryParameterKey = "testSetValue";
 
-    public UrlPersistenceService_SetValueTests() : base()
+    public UrlPersistenceService_SetValueTests()
     {
         Services.AddSingleton<IUrlQueryStringFormatter, UrlQueryStringFormatter>();
-        Services.AddSingleton<UrlPersistenceService>();
+        Services.AddScoped<UrlPersistenceService>();
     }
 
     public static IEnumerable<object?[]> SetValue_Data => UrlUtilities_TestHelpers.ValueToString_Data;

--- a/test/Blazor.Tests/Persistence/UrlUtilities_TestHelpers.cs
+++ b/test/Blazor.Tests/Persistence/UrlUtilities_TestHelpers.cs
@@ -37,14 +37,14 @@ internal static class UrlUtilities_TestHelpers
         ["", Option.None<string>()],
         ["  \t ", Option.None<string>()],
         ["hello", Option.Some("hello")],
-        
+
         // None GUIDs
         ["", Option.None<Guid>()],
         ["", Option.None<Guid?>()],
         ["ThisIsNotValid", Option.None<Guid>()],
         ["RightLengthButInvalid!", Option.None<Guid>()],
         ["FullUnco-mpre-ssed-Leng-thButInvalid", Option.None<Guid>()],
-        
+
         // Compact GUIDs
         ["AAAAAAAAAAAAAAAAAAAAAA", Option.Some(Guid.Empty)],
         ["ULV9Za34j0GZJ13FVSWOeA", Option.Some(Guid.Parse("657db550-f8ad-418f-9927-5dc555258e78"))],

--- a/test/Core.Tests/Core.Tests.csproj
+++ b/test/Core.Tests/Core.Tests.csproj
@@ -3,20 +3,12 @@
   <PropertyGroup>
     <AssemblyName>Tyne.Core.Tests</AssemblyName>
     <RootNamespace>Tyne</RootNamespace>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Core\Core.csproj" />
     <ProjectReference Include="..\TestUtilities\TestUtilities.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="coverlet.collector" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="NSubstitute" />
-    <PackageReference Include="NSubstitute.Analyzers.CSharp" PrivateAssets="all" />
-    <PackageReference Include="xunit" />
-    <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" />
   </ItemGroup>
 
   <Import Project="../../eng/Tests.props" />

--- a/test/Core.Tests/Core.Tests.csproj
+++ b/test/Core.Tests/Core.Tests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
     <AssemblyName>Tyne.Core.Tests</AssemblyName>
     <RootNamespace>Tyne</RootNamespace>
   </PropertyGroup>

--- a/test/Core.Tests/Error/ErrorEqualityTests.cs
+++ b/test/Core.Tests/Error/ErrorEqualityTests.cs
@@ -41,10 +41,11 @@ public class ErrorEqualityTests
     [Fact]
     public void From_DifferentCodeAndSameMessage_AreNotEqual()
     {
-        Assert.NotEqual(137, TestError.Code);
+        const string code1 = "test-code-1";
+        const string code2 = "test-code-2";
 
-        var error1 = Error.From(TestError.Code, TestError.Message);
-        var error2 = Error.From(137, TestError.Message);
+        var error1 = Error.From(code1, TestError.Message);
+        var error2 = Error.From(code2, TestError.Message);
 
         AssertError.AreNotEqual(error1, error2);
     }

--- a/test/Core.Tests/Error/ErrorJsonTests.cs
+++ b/test/Core.Tests/Error/ErrorJsonTests.cs
@@ -50,7 +50,7 @@ public class ErrorJsonTests
     {
         // Arrange
         var expectedError = TestError.Instance;
-        var json = @$"{{""Code"":{TestError.Code},""Message"":""{TestError.Message}"",""CausedBy"":{{""Message"":""Some exception.""}}}}";
+        var json = @$"{{""Code"":""{TestError.Code}"",""Message"":""{TestError.Message}"",""CausedBy"":{{""Message"":""Some exception.""}}}}";
 
         // Act
         var actualError = JsonSerializer.Deserialize<Error>(json);
@@ -65,7 +65,7 @@ public class ErrorJsonTests
     {
         // Arrange
         var expectedError = TestError.Instance;
-        var json = @$"{{""Code"":{TestError.Code},""Message"":""{TestError.Message}"",""CausedBy"":{{""HasValue"":true,""Value"":{{""Message"":""Some exception.""}}}}}}";
+        var json = @$"{{""Code"":""{TestError.Code}"",""Message"":""{TestError.Message}"",""CausedBy"":{{""HasValue"":true,""Value"":{{""Message"":""Some exception.""}}}}}}";
 
         // Act
         var actualError = JsonSerializer.Deserialize<Error>(json);

--- a/test/Core.Tests/Error/ErrorOtherTests.cs
+++ b/test/Core.Tests/Error/ErrorOtherTests.cs
@@ -8,26 +8,26 @@ public class ErrorOtherTests
         AssertError.IsDefault(Error.Default);
 
         // The default error message shouldn't be null or empty
-        Assert.False(string.IsNullOrWhiteSpace(Error.DefaultErrorMessage));
+        Assert.False(string.IsNullOrWhiteSpace(Error.DefaultMessage));
 
         // And it should be valid
-        Assert.True(Error.IsValidMessage(Error.DefaultErrorMessage));
+        Assert.True(Internal.Error.IsValidMessage(Error.DefaultMessage));
 
         // The default error should use the default code
         Assert.Equal(Error.DefaultCode, Error.Default.Code);
 
         // And use the default error message
-        Assert.Equal(Error.DefaultErrorMessage, Error.Default.Message);
+        Assert.Equal(Error.DefaultMessage, Error.Default.Message);
     }
 
     [Fact]
     public void IsValidMessage_Works()
     {
-        Assert.False(Error.IsValidMessage(null));
-        Assert.False(Error.IsValidMessage(""));
-        Assert.False(Error.IsValidMessage("\t "));
+        Assert.False(Internal.Error.IsValidMessage(null));
+        Assert.False(Internal.Error.IsValidMessage(""));
+        Assert.False(Internal.Error.IsValidMessage("\t "));
 
-        Assert.True(Error.IsValidMessage("An error message"));
+        Assert.True(Internal.Error.IsValidMessage("An error message"));
     }
 
     [Fact]
@@ -92,10 +92,44 @@ public class ErrorOtherTests
     }
 
     [Fact]
-    public void ToString_Works()
+    public void ToString_IncludeCode_WithCode_ContainsCodeAndMessage()
     {
-        var error = Error.From(42, "Some error");
+        const string code = "ErrorOtherTestsErrorCode";
+        const string message = "Some error message.";
 
-        Assert.Equal("Error(42: Some error)", error.ToString());
+        var error = Error.From(code, message);
+
+        Assert.Equal($"Error({code}: {message})", error.ToString(includeCode: true));
+    }
+
+    [Fact]
+    public void ToString_IncludeCode_WithDefaultCode_ContainsOnlyMessage()
+    {
+        const string message = "Some error message.";
+
+        var error = Error.From(message);
+
+        Assert.Equal($"Error({message})", error.ToString(includeCode: true));
+    }
+
+    [Fact]
+    public void ToString_DoNotIncludeCode_WithCode_OnlyMessage()
+    {
+        const string code = "ErrorOtherTestsErrorCode";
+        const string message = "Some error message.";
+
+        var error = Error.From(code, message);
+
+        Assert.Equal($"Error({message})", error.ToString(includeCode: false));
+    }
+
+    [Fact]
+    public void ToString_DoNotIncludeCode_WithDefaultCode_ContainsOnlyMessage()
+    {
+        const string message = "Some error message.";
+
+        var error = Error.From(message);
+
+        Assert.Equal($"Error({message})", error.ToString(includeCode: false));
     }
 }

--- a/test/Core.Tests/Result/ResultOtherTests.cs
+++ b/test/Core.Tests/Result/ResultOtherTests.cs
@@ -339,7 +339,7 @@ public class ResultOtherTests
         var result2 = Result.Error<int?>(error);
         var result3 = Result.Error<string>(error);
 
-        var errorToString = error.ToString();
+        var errorToString = error.ToString(includeCode: true);
         Assert.Equal(errorToString, result1.ToString());
         Assert.Equal(errorToString, result2.ToString());
         Assert.Equal(errorToString, result3.ToString());

--- a/test/Core.Tests/TestError.cs
+++ b/test/Core.Tests/TestError.cs
@@ -2,9 +2,9 @@ namespace Tyne;
 
 internal static class TestError
 {
-    public const int Code = 101;
+    public const string Code = "Tyne.Core.Tests.ErrorCode";
     public const string Message = "Test result error message.";
-    public const string Json = @$"{{""Code"":101,""Message"":""{Message}""}}";
+    public const string Json = @$"{{""Code"":""{Code}"",""Message"":""{Message}""}}";
 
     private static readonly Error _instance = Error.From(Code, Message);
     public static ref readonly Error Instance => ref _instance;
@@ -13,6 +13,6 @@ internal static class TestError
     {
         // Test code and message should not equal defaults
         Assert.NotEqual(Code, Error.DefaultCode);
-        Assert.NotEqual(Message, Error.DefaultErrorMessage);
+        Assert.NotEqual(Message, Error.DefaultMessage);
     }
 }

--- a/test/Core.Tests/Utilities/MethodInfoExtensionsTests.cs
+++ b/test/Core.Tests/Utilities/MethodInfoExtensionsTests.cs
@@ -15,7 +15,7 @@ public class MethodInfoExtensionsTests
     private static MethodInfo GetMethod(string methodName)
     {
         var method = typeof(MethodInfoExtensionsTests).GetMethod(methodName, GetMethodBindingFlags)!;
-        Debug.Assert(method is not null, "Test method not found.", $"Expected test method '{methodName}' not found.");
+        Debug.Assert(method is not null, "Test method not found.", $"Expected test method was '{methodName}' not found.");
         return method;
     }
 

--- a/test/EventIdTests/EventIdTests.csproj
+++ b/test/EventIdTests/EventIdTests.csproj
@@ -3,19 +3,11 @@
   <PropertyGroup>
     <AssemblyName>Tyne.EventIdTests</AssemblyName>
     <RootNamespace>Tyne</RootNamespace>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="coverlet.collector" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="NSubstitute" />
-    <PackageReference Include="NSubstitute.Analyzers.CSharp" PrivateAssets="all" />
-    <PackageReference Include="xunit" />
-    <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/EventIdTests/EventIdTests.csproj
+++ b/test/EventIdTests/EventIdTests.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
     <AssemblyName>Tyne.EventIdTests</AssemblyName>
     <RootNamespace>Tyne</RootNamespace>
   </PropertyGroup>

--- a/test/HttpMediator.Client.UnitTests/HttpMediator.Client.UnitTests.csproj
+++ b/test/HttpMediator.Client.UnitTests/HttpMediator.Client.UnitTests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <AssemblyName>Tyne.HttpMediator.Client.UnitTests</AssemblyName>
     <RootNamespace>Tyne.HttpMediator.Client</RootNamespace>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,14 +14,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" PrivateAssets="all" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.9.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="NSubstitute" />
-    <PackageReference Include="NSubstitute.Analyzers.CSharp" PrivateAssets="all" />
-    <PackageReference Include="xunit" />
-    <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
   </ItemGroup>
 

--- a/test/HttpMediator.Client.UnitTests/Middleware/Implementations/FluentValidationMiddlewareTests.cs
+++ b/test/HttpMediator.Client.UnitTests/Middleware/Implementations/FluentValidationMiddlewareTests.cs
@@ -52,5 +52,5 @@ public class FluentValidationMiddlewareTests
     }
 
     private static HttpMediatorDelegate<ValidatedRequest, ValidatedResponse> CreateAssertFailNextDelegate() =>
-        _ => throw new FailException($"{nameof(FluentValidationMiddleware)} should be terminal for invalid requests, and not invoke the next delegate.");
+        _ => throw FailException.ForFailure($"{nameof(FluentValidationMiddleware)} should be terminal for invalid requests, and not invoke the next delegate.");
 }

--- a/test/HttpMediator.Client.UnitTests/Middleware/Implementations/HttpSenderMiddlewareTests.cs
+++ b/test/HttpMediator.Client.UnitTests/Middleware/Implementations/HttpSenderMiddlewareTests.cs
@@ -71,5 +71,5 @@ public class HttpSenderMiddlewareTests
 
     private static HttpMediatorDelegate<TRequest, TResponse> CreateAssertFailNextDelegate<TRequest, TResponse>()
         where TRequest : IHttpRequestBase<TResponse> =>
-        _ => throw new FailException($"{nameof(HttpSenderMiddleware)} should be terminal and not invoke the next delegate.");
+        _ => throw FailException.ForFailure($"{nameof(HttpSenderMiddleware)} should be terminal and not invoke the next delegate.");
 }

--- a/test/HttpMediator.Client.UnitTests/ResultReader/HttpResponseResultReaderTest.cs
+++ b/test/HttpMediator.Client.UnitTests/ResultReader/HttpResponseResultReaderTest.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Json;
 using System.Text.Json;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using Tyne.Internal.HttpMediator;
 
 namespace Tyne.HttpMediator.Client;
 
@@ -134,7 +135,7 @@ public class HttpResponseResultReaderTest
         using var scope = HttpMediatorClientTestScope.Create();
         var jsonOptions = scope.Services.GetRequiredService<IOptions<JsonSerializerOptions>>().Value;
 
-        var expectedError = Error.From(451, "Response result reader test error.");
+        var expectedError = Error.From("Tyne.HttpMediator.Client.UnitTests.Error", "Response result reader test error.");
         var expectedResult = HttpResult.Error<int>(expectedError, ErrorStatusCode);
         using var responseMessage = CreateHttpResponseMessage(expectedResult, jsonOptions);
         var resultReader = scope.Services.GetRequiredService<IHttpResponseResultReader>();

--- a/test/HttpMediator.Client.UnitTests/ResultReader/HttpResponseResultReaderTest.cs
+++ b/test/HttpMediator.Client.UnitTests/ResultReader/HttpResponseResultReaderTest.cs
@@ -1,8 +1,8 @@
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 namespace Tyne.HttpMediator.Client;
 

--- a/test/HttpMediator.Client.UnitTests/Utilities/MockHttpRequestHandlerExtensions.cs
+++ b/test/HttpMediator.Client.UnitTests/Utilities/MockHttpRequestHandlerExtensions.cs
@@ -1,8 +1,8 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Net.Http.Json;
-using RichardSzalay.MockHttp;
-using System.Web;
 using System.Text.Json;
+using System.Web;
+using RichardSzalay.MockHttp;
 
 namespace Tyne.HttpMediator.Client;
 
@@ -27,10 +27,8 @@ public static class MockHttpRequestHandlerExtensions
         {
             var requestUri = http.RequestUri!.Query;
             var queryString = HttpUtility.ParseQueryString(requestUri);
-            var requestStr = queryString[HttpSenderRequestMessageFactory.QueryParameterName];
-            if (requestStr is null)
-                throw new InvalidOperationException("Test HTTP handler could not get request from query string.");
-
+            var requestStr = queryString[HttpSenderRequestMessageFactory.QueryParameterName]
+                ?? throw new InvalidOperationException("Test HTTP handler could not get request from query string.");
             var request = JsonSerializer.Deserialize<TRequest>(requestStr, options: HttpMediatorClientTestScope.JsonSerializerOptions)
                 ?? throw new InvalidOperationException("Test HTTP handler could not parse request from URI.");
 

--- a/test/HttpMediator.Core.UnitTests/HttpMediator.Core.UnitTests.csproj
+++ b/test/HttpMediator.Core.UnitTests/HttpMediator.Core.UnitTests.csproj
@@ -3,21 +3,13 @@
   <PropertyGroup>
     <AssemblyName>Tyne.HttpMediator.Core.UnitTests</AssemblyName>
     <RootNamespace>Tyne.HttpMediator</RootNamespace>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\HttpMediator.Core\HttpMediator.Core.csproj" />
     <ProjectReference Include="..\HttpMediator.TestUtilities\HttpMediator.TestUtilities.csproj" />
     <ProjectReference Include="..\TestUtilities\TestUtilities.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="coverlet.collector" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="NSubstitute" />
-    <PackageReference Include="NSubstitute.Analyzers.CSharp" PrivateAssets="all" />
-    <PackageReference Include="xunit" />
-    <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" />
   </ItemGroup>
 
   <Import Project="../../eng/Tests.props" />

--- a/test/HttpMediator.Core.UnitTests/HttpResult/HttpResultCodesTests.cs
+++ b/test/HttpMediator.Core.UnitTests/HttpResult/HttpResultCodesTests.cs
@@ -71,7 +71,7 @@ public class HttpResultCodesTests
     private static void AssertStatusCode_Message(HttpStatusCode expectedStatusCode, Func<string, HttpResult<int>> resultFunc) =>
         AssertStatusCodeCore(expectedStatusCode, resultFunc(TestError.Message));
 
-    private static void AssertStatusCode_CodeAndMessage(HttpStatusCode expectedStatusCode, Func<int, string, HttpResult<int>> resultFunc) =>
+    private static void AssertStatusCode_CodeAndMessage(HttpStatusCode expectedStatusCode, Func<string, string, HttpResult<int>> resultFunc) =>
         AssertStatusCodeCore(expectedStatusCode, resultFunc(TestError.Code, TestError.Message));
 
     private static void AssertStatusCode_Error(HttpStatusCode expectedStatusCode, Func<Error, HttpResult<int>> resultFunc) =>

--- a/test/HttpMediator.Core.UnitTests/TestError.cs
+++ b/test/HttpMediator.Core.UnitTests/TestError.cs
@@ -4,9 +4,9 @@ namespace Tyne.HttpMediator;
 
 internal static class TestError
 {
-    public const int Code = 101;
+    public const string Code = "Tyne.HttpMediator.Tests.ErrorCode";
     public const string Message = "Test result error message.";
-    public const string Json = @$"{{""Code"":101,""Message"":""{Message}""}}";
+    public const string Json = @$"{{""Code"":""{Code}"",""Message"":""{Message}""}}";
     public const HttpStatusCode StatusCode = (HttpStatusCode)418;
 
     private static readonly Error _instance = Error.From(Code, Message);
@@ -15,7 +15,7 @@ internal static class TestError
     static TestError()
     {
         // Test code and message should not equal defaults
-        Assert.NotEqual(Code, Error.DefaultCode);
+        Assert.NotEqual(Code, Error.Default.Code);
         Assert.NotEqual(Message, Error.Default.Message);
     }
 }

--- a/test/HttpMediator.IntegrationTests.TestWebApp/HttpMediator.IntegrationTests.TestWebApp.csproj
+++ b/test/HttpMediator.IntegrationTests.TestWebApp/HttpMediator.IntegrationTests.TestWebApp.csproj
@@ -4,6 +4,9 @@
     <AssemblyName>Tyne.HttpMediator.IntegrationTests.TestApp</AssemblyName>
     <RootNamespace>Tyne.HttpMediator</RootNamespace>
     <IsTestProject>false</IsTestProject>
+    <!-- Prevents dotnet pack from trying to pack this, and then warning when it can't -->
+    <IsPackable>false</IsPackable>
+    <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/HttpMediator.IntegrationTests/HttpMediator.IntegrationTests.csproj
+++ b/test/HttpMediator.IntegrationTests/HttpMediator.IntegrationTests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <AssemblyName>Tyne.HttpMediator.IntegrationTests</AssemblyName>
     <RootNamespace>Tyne.HttpMediator</RootNamespace>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
@@ -17,13 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.16" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="NSubstitute" />
-    <PackageReference Include="NSubstitute.Analyzers.CSharp" PrivateAssets="all" />
-    <PackageReference Include="xunit" />
-    <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" />
   </ItemGroup>
 
   <Import Project="../../eng/Tests.props" />

--- a/test/HttpMediator.IntegrationTests/HttpMediator.IntegrationTests.csproj
+++ b/test/HttpMediator.IntegrationTests/HttpMediator.IntegrationTests.csproj
@@ -4,6 +4,9 @@
     <AssemblyName>Tyne.HttpMediator.IntegrationTests</AssemblyName>
     <RootNamespace>Tyne.HttpMediator</RootNamespace>
     <IsTestProject>true</IsTestProject>
+    <!-- Prevents dotnet pack from trying to pack this, and then warning when it can't -->
+    <IsPackable>false</IsPackable>
+    <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/HttpMediator.Server.UnitTests/HttpMediator.Server.UnitTests.csproj
+++ b/test/HttpMediator.Server.UnitTests/HttpMediator.Server.UnitTests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <AssemblyName>Tyne.HttpMediator.Server.UnitTests</AssemblyName>
     <RootNamespace>Tyne.HttpMediator.Server</RootNamespace>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
@@ -10,15 +11,6 @@
     <ProjectReference Include="..\..\src\HttpMediator.Server\HttpMediator.Server.csproj" />
     <ProjectReference Include="..\HttpMediator.TestUtilities\HttpMediator.TestUtilities.csproj" />
     <ProjectReference Include="..\TestUtilities\TestUtilities.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="coverlet.collector" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="NSubstitute" />
-    <PackageReference Include="NSubstitute.Analyzers.CSharp" PrivateAssets="all" />
-    <PackageReference Include="xunit" />
-    <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" />
   </ItemGroup>
 
   <Import Project="../../eng/Tests.props" />

--- a/test/HttpMediator.TestUtilities/AssertHttpResult.cs
+++ b/test/HttpMediator.TestUtilities/AssertHttpResult.cs
@@ -40,12 +40,12 @@ public static class AssertHttpResult
     }
 
     public static Error IsError<T>(HttpStatusCode expectedStatusCode, string expectedErrorMessage, in HttpResult<T> actual) =>
-        IsError(expectedStatusCode, Error.DefaultCode, expectedErrorMessage, null, actual);
+        IsError(expectedStatusCode, Error.Default.Code, expectedErrorMessage, null, actual);
 
-    public static Error IsError<T>(HttpStatusCode expectedStatusCode, int expectedErrorCode, string expectedErrorMessage, in HttpResult<T> actual) =>
+    public static Error IsError<T>(HttpStatusCode expectedStatusCode, string expectedErrorCode, string expectedErrorMessage, in HttpResult<T> actual) =>
         IsError(expectedStatusCode, expectedErrorCode, expectedErrorMessage, null, actual);
 
-    public static Error IsError<T>(HttpStatusCode expectedStatusCode, int expectedErrorCode, string expectedErrorMessage, Exception? expectedException, in HttpResult<T> actual) =>
+    public static Error IsError<T>(HttpStatusCode expectedStatusCode, string expectedErrorCode, string expectedErrorMessage, Exception? expectedException, in HttpResult<T> actual) =>
         IsError(expectedStatusCode, Error.From(expectedErrorCode, expectedErrorMessage, expectedException), actual);
 
     public static void AreEqual<T>(in HttpResult<T> expected, in HttpResult<T> actual)

--- a/test/HttpMediator.TestUtilities/AssertHttpResult.cs
+++ b/test/HttpMediator.TestUtilities/AssertHttpResult.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Net;
 using Xunit;
 namespace Tyne.HttpMediator;
@@ -47,8 +48,6 @@ public static class AssertHttpResult
     public static Error IsError<T>(HttpStatusCode expectedStatusCode, int expectedErrorCode, string expectedErrorMessage, Exception? expectedException, in HttpResult<T> actual) =>
         IsError(expectedStatusCode, Error.From(expectedErrorCode, expectedErrorMessage, expectedException), actual);
 
-    private static IEquatable<HttpResult<T>> AsEquatable<T>(in HttpResult<T> result) => result;
-
     public static void AreEqual<T>(in HttpResult<T> expected, in HttpResult<T> actual)
     {
         ArgumentNullException.ThrowIfNull(expected);
@@ -67,8 +66,8 @@ public static class AssertHttpResult
         Assert.True(expected.Equals(actual), "Equals method should return true.");
         Assert.True(actual.Equals(expected), "Equals method  should return true.");
 
-        Assert.True(AsEquatable(expected).Equals(actual), "Equatable.Equals method should return true.");
-        Assert.True(AsEquatable(actual).Equals(expected), "Equatable.Equals method should return true.");
+        Assert.True(((IEquatable<HttpResult<T>>)expected).Equals(actual), "Equatable.Equals method should return true.");
+        Assert.True(((IEquatable<HttpResult<T>>)actual).Equals(expected), "Equatable.Equals method should return true.");
 
         Assert.True(expected.Equals(actual as object), "Equals (as object) method should return true.");
         Assert.True(actual.Equals(expected as object), "Equals (as object) method should return true.");
@@ -94,8 +93,8 @@ public static class AssertHttpResult
         Assert.False(expected.Equals(actual));
         Assert.False(actual.Equals(expected));
 
-        Assert.False(AsEquatable(expected).Equals(actual));
-        Assert.False(AsEquatable(actual).Equals(expected));
+        Assert.False(((IEquatable<HttpResult<T>>)expected).Equals(actual));
+        Assert.False(((IEquatable<HttpResult<T>>)actual).Equals(expected));
 
         Assert.False(expected.Equals(actual as object));
         Assert.False(actual.Equals(expected as object));

--- a/test/MediatorEndpoints.IntegrationTests.TestWebApp/MediatorEndpoints.IntegrationTests.TestWebApp.csproj
+++ b/test/MediatorEndpoints.IntegrationTests.TestWebApp/MediatorEndpoints.IntegrationTests.TestWebApp.csproj
@@ -4,6 +4,9 @@
     <AssemblyName>Tyne.MediatorEndpoints.IntegrationTests.TestApp</AssemblyName>
     <RootNamespace>Tyne.MediatorEndpoints</RootNamespace>
     <IsTestProject>false</IsTestProject>
+    <!-- Prevents dotnet pack from trying to pack this, and then warning when it can't -->
+    <IsPackable>false</IsPackable>
+    <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/MediatorEndpoints.IntegrationTests.TestWebApp/MediatorEndpoints.IntegrationTests.TestWebApp.csproj
+++ b/test/MediatorEndpoints.IntegrationTests.TestWebApp/MediatorEndpoints.IntegrationTests.TestWebApp.csproj
@@ -15,9 +15,6 @@
     <PackageReference Include="FluentValidation" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.8.1" />
     <PackageReference Include="MediatR" />
-    <PackageReference Include="NSubstitute" />
-    <PackageReference Include="NSubstitute.Analyzers.CSharp" PrivateAssets="all" />
-    <PackageReference Include="xunit" />
   </ItemGroup>
 
   <Import Project="../../eng/Tests.props" />

--- a/test/MediatorEndpoints.IntegrationTests/MediatorEndpoints.IntegrationTests.csproj
+++ b/test/MediatorEndpoints.IntegrationTests/MediatorEndpoints.IntegrationTests.csproj
@@ -4,6 +4,9 @@
     <AssemblyName>Tyne.MediatorEndpoints.IntegrationTests</AssemblyName>
     <RootNamespace>Tyne.MediatorEndpoints</RootNamespace>
     <IsTestProject>true</IsTestProject>
+    <!-- Prevents dotnet pack from trying to pack this, and then warning when it can't -->
+    <IsPackable>false</IsPackable>
+    <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/MediatorEndpoints.IntegrationTests/MediatorEndpoints.IntegrationTests.csproj
+++ b/test/MediatorEndpoints.IntegrationTests/MediatorEndpoints.IntegrationTests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <AssemblyName>Tyne.MediatorEndpoints.IntegrationTests</AssemblyName>
     <RootNamespace>Tyne.MediatorEndpoints</RootNamespace>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
@@ -11,13 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.16" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="NSubstitute" />
-    <PackageReference Include="NSubstitute.Analyzers.CSharp" PrivateAssets="all" />
-    <PackageReference Include="xunit" />
-    <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" />
   </ItemGroup>
 
   <Import Project="../../eng/Tests.props" />

--- a/test/TestUtilities/AssertError.cs
+++ b/test/TestUtilities/AssertError.cs
@@ -5,8 +5,6 @@ public static class AssertError
     public static void IsDefault(in Error actual) =>
         AreEqual(Error.Default, actual);
 
-    private static IEquatable<Error> AsEquatable(in Error error) => error;
-
     public static void AreEqual(in Error expected, in Error actual)
     {
         ArgumentNullException.ThrowIfNull(expected);
@@ -23,8 +21,8 @@ public static class AssertError
         Assert.True(expected.Equals(actual));
         Assert.True(actual.Equals(expected));
 
-        Assert.True(AsEquatable(expected).Equals(actual));
-        Assert.True(AsEquatable(actual).Equals(expected));
+        Assert.True(((IEquatable<Error>)expected).Equals(actual));
+        Assert.True(((IEquatable<Error>)actual).Equals(expected));
 
         Assert.True(expected.Equals(actual as object));
         Assert.True(actual.Equals(expected as object));
@@ -48,8 +46,8 @@ public static class AssertError
         Assert.False(expected.Equals(actual));
         Assert.False(actual.Equals(expected));
 
-        Assert.False(AsEquatable(expected).Equals(actual));
-        Assert.False(AsEquatable(actual).Equals(expected));
+        Assert.False(((IEquatable<Error>)expected).Equals(actual));
+        Assert.False(((IEquatable<Error>)actual).Equals(expected));
 
         Assert.False(expected.Equals(actual as object));
         Assert.False(actual.Equals(expected as object));

--- a/test/TestUtilities/AssertOption.cs
+++ b/test/TestUtilities/AssertOption.cs
@@ -18,8 +18,6 @@ public static class AssertOption
         Assert.False(actual.HasValue);
     }
 
-    private static IEquatable<Option<T>> AsEquatable<T>(in Option<T> option) => option;
-
     public static void AreEqual<T>(in Option<T> expected, in Option<T> actual)
     {
         Assert.Equal(expected, actual);
@@ -33,8 +31,8 @@ public static class AssertOption
         Assert.True(expected.Equals(actual));
         Assert.True(actual.Equals(expected));
 
-        Assert.True(AsEquatable(expected).Equals(actual));
-        Assert.True(AsEquatable(actual).Equals(expected));
+        Assert.True(((IEquatable<Option<T>>)expected).Equals(actual));
+        Assert.True(((IEquatable<Option<T>>)actual).Equals(expected));
 
         Assert.True(expected.Equals(actual as object));
         Assert.True(actual.Equals(expected as object));
@@ -55,8 +53,8 @@ public static class AssertOption
         Assert.False(expected.Equals(actual));
         Assert.False(actual.Equals(expected));
 
-        Assert.False(AsEquatable(expected).Equals(actual));
-        Assert.False(AsEquatable(actual).Equals(expected));
+        Assert.False(((IEquatable<Option<T>>)expected).Equals(actual));
+        Assert.False(((IEquatable<Option<T>>)actual).Equals(expected));
 
         Assert.False(expected.Equals(actual as object));
         Assert.False(actual.Equals(expected as object));

--- a/test/TestUtilities/AssertResult.cs
+++ b/test/TestUtilities/AssertResult.cs
@@ -51,8 +51,6 @@ public static class AssertResult
     public static Error IsError<T>(int expectedErrorCode, string expectedErrorMessage, Exception? expectedException, in Result<T> actual) =>
         IsError(Error.From(expectedErrorCode, expectedErrorMessage, expectedException), actual);
 
-    private static IEquatable<Result<T>> AsEquatable<T>(in Result<T> result) => result;
-
     public static void AreEqual<T>(in Result<T> expected, in Result<T> actual)
     {
         ArgumentNullException.ThrowIfNull(expected);
@@ -69,8 +67,8 @@ public static class AssertResult
         Assert.True(expected.Equals(actual), "Equals method should return true.");
         Assert.True(actual.Equals(expected), "Equals method  should return true.");
 
-        Assert.True(AsEquatable(expected).Equals(actual), "Equatable.Equals method should return true.");
-        Assert.True(AsEquatable(actual).Equals(expected), "Equatable.Equals method should return true.");
+        Assert.True(((IEquatable<Result<T>>)expected).Equals(actual), "Equatable.Equals method should return true.");
+        Assert.True(((IEquatable<Result<T>>)actual).Equals(expected), "Equatable.Equals method should return true.");
 
         Assert.True(expected.Equals(actual as object), "Equals (as object) method should return true.");
         Assert.True(actual.Equals(expected as object), "Equals (as object) method should return true.");
@@ -94,8 +92,8 @@ public static class AssertResult
         Assert.False(expected.Equals(actual));
         Assert.False(actual.Equals(expected));
 
-        Assert.False(AsEquatable(expected).Equals(actual));
-        Assert.False(AsEquatable(actual).Equals(expected));
+        Assert.False(((IEquatable<Result<T>>)expected).Equals(actual));
+        Assert.False(((IEquatable<Result<T>>)actual).Equals(expected));
 
         Assert.False(expected.Equals(actual as object));
         Assert.False(actual.Equals(expected as object));

--- a/test/TestUtilities/AssertResult.cs
+++ b/test/TestUtilities/AssertResult.cs
@@ -45,10 +45,10 @@ public static class AssertResult
     public static Error IsError<T>(string expectedErrorMessage, in Result<T> actual) =>
         IsError(Error.DefaultCode, expectedErrorMessage, null, actual);
 
-    public static Error IsError<T>(int expectedErrorCode, string expectedErrorMessage, in Result<T> actual) =>
+    public static Error IsError<T>(string expectedErrorCode, string expectedErrorMessage, in Result<T> actual) =>
         IsError(expectedErrorCode, expectedErrorMessage, null, actual);
 
-    public static Error IsError<T>(int expectedErrorCode, string expectedErrorMessage, Exception? expectedException, in Result<T> actual) =>
+    public static Error IsError<T>(string expectedErrorCode, string expectedErrorMessage, Exception? expectedException, in Result<T> actual) =>
         IsError(Error.From(expectedErrorCode, expectedErrorMessage, expectedException), actual);
 
     public static void AreEqual<T>(in Result<T> expected, in Result<T> actual)

--- a/test/TestUtilities/TestUtilities.csproj
+++ b/test/TestUtilities/TestUtilities.csproj
@@ -3,16 +3,8 @@
   <PropertyGroup>
     <AssemblyName>Tyne.TestUtilities</AssemblyName>
     <RootNamespace>Tyne</RootNamespace>
+    <IsTestProject>false</IsTestProject>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="coverlet.collector" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="NSubstitute" />
-    <PackageReference Include="NSubstitute.Analyzers.CSharp" PrivateAssets="all" />
-    <PackageReference Include="xunit" />
-    <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Core\Core.csproj" />

--- a/test/TestUtilities/TestUtilities.csproj
+++ b/test/TestUtilities/TestUtilities.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
     <AssemblyName>Tyne.TestUtilities</AssemblyName>
     <RootNamespace>Tyne</RootNamespace>
   </PropertyGroup>


### PR DESCRIPTION
- Multi-target .NET 7/8/9
- Remove obsolete serialization APIs #118
- Use strings as Error codes #120
- `MapNotFoundFallback` methods are deprecated in favour of `MapFallbackToNotFound` methods
  - These function identically, but are better aligned with ASP.NET Core naming
- Various tweaks/optimisations